### PR TITLE
Trimdata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,8 @@ but non-authoritative.  If in question, the DocDB version of a design
 parameter is correct.  This is intended to reflect the same information
 while being more conveniently organized and formatted for simulations.
 
+**PLEASE KEEP THIS FILE IN SYNC WITH THE EQUIVALENT FILE IN SVN.**
+
 Desimodel Code
 --------------
 

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,12 @@ but non-authoritative.  If in question, the DocDB version of a design
 parameter is correct.  This is intended to reflect the same information
 while being more conveniently organized and formatted for simulations.
 
+Desimodel Code
+--------------
+
+The svn product described below contains only the *data* associated with
+desimodel. The code is in Github: https://github.com/desihub/desimodel.
+
 Desimodel Data
 --------------
 
@@ -108,6 +114,12 @@ bb
 In addition to these historical branches, there is a permanent 'testing' branch
 that contains smaller versions of the desimodel files.  This branch is
 intended for use in desimodel unit tests.
+
+Tagging
+-------
+
+If *either* the data *or* the code changes, a new tag should be created in
+both git and svn.
 
 Full Documentation
 ------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,7 @@ Contents
     :maxdepth: 1
 
     release_notes.rst
+    testing.rst
     fiberpos.rst
     footprint.rst
     psfspots.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,37 +10,32 @@ This is the documentation for desimodel.
 Contents
 ========
 
-The ``toctree`` directive can be used to link to other files in this
-directory and even display their sections.  See `the toctree documentation`_.
-
-.. _`the toctree documentation`: http://sphinx-doc.org/markup/toctree.html
-
 .. toctree::
-   :maxdepth: 2
+    :maxdepth: 1
 
-   fiberpos.rst
-   footprint.rst
-   psfspots.rst
-   throughput.rst
+    release_notes.rst
+    fiberpos.rst
+    footprint.rst
+    psfspots.rst
+    throughput.rst
 
-Release Notes
-=============
-
-.. toctree::
-   :maxdepth: 1
-
-   release_notes.rst
-
-The desimodel package
-=====================
-
-This is used to include docstrings from modules. See `the autodoc documentation`_.
-
-.. _`the autodoc documentation`: http://sphinx-doc.org/ext/autodoc.html?highlight=automodule#directive-automodule
+The desimodel package/API
+=========================
 
 .. automodule:: desimodel
-   :members:
-   :imported-members:
+    :members:
+
+.. automodule:: desimodel.focalplane
+    :members:
+
+.. automodule:: desimodel.install
+    :members:
+
+.. automodule:: desimodel.io
+    :members:
+
+.. automodule:: desimodel.trim
+    :members:
 
 Indices and tables
 ==================

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,7 +6,7 @@ desimodel Release Notes
 ------------------
 
 * "First" post-separation tag.
-* No changes yet!
+* Add code to create trimmed versions of the data.
 
 0.4.2 (2016-02-04)
 ------------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -2,7 +2,7 @@
 desimodel Release Notes
 =======================
 
-1.0.0 (unreleased)
+0.5.0 (unreleased)
 ------------------
 
 * "First" post-separation tag.

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,7 @@ desimodel Release Notes
 
 * "First" post-separation tag.
 * Add code to create trimmed versions of the data.
+* No significant changes to *data* from 0.4.2.
 
 0.4.2 (2016-02-04)
 ------------------

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -1,0 +1,12 @@
+=================
+Testing desimodel
+=================
+
+Introduction
+------------
+
+Testing desimodel is a bit tricky since most of the code involves reading
+data files that are not included with the git product.  In addition, the data
+files can be rather large, both individually and as a package. This document
+describes how to create lightweight test branches of the desimodel *data*
+that can be used for rapid testing.

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -61,6 +61,6 @@ How to Create a Test Branch
 
 7. Now tests can get this lightweight branch on-the-fly with
 
-    svn export $base/test-1.0
+    svn export $base/branches/test-1.0
 
 If you find any problems, just wipe out the branch and start again.

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -10,3 +10,44 @@ data files that are not included with the git product.  In addition, the data
 files can be rather large, both individually and as a package. This document
 describes how to create lightweight test branches of the desimodel *data*
 that can be used for rapid testing.
+
+When to Create a Test Branch
+----------------------------
+
+**The word "branch(es)" below refers to svn branches not git branches,
+unless otherwise noted.**
+
+Test branches should track major changes to the code and data, but should
+*not* change for minor bug fixes in the code.  For example, a branch named
+'test-1.0' should work with all code that has a tag of the form 1.0.x.
+Similarly a 'test-1.1' branch should work with all code that has a tag of the
+form 1.1.x.
+
+Test branches should be created immedately after the trunk has been tagged
+to produce a new minor version.  For example, immedately after a svn tag
+'1.0.0' is created, the 'test-1.0' branch should be created before there
+are any additional changes to the trunkk.
+
+How to Create a Test Branch
+---------------------------
+
+1. Create a branch in the standard way (for clarity the full svn URLs are omitted)::
+
+    svn copy trunk branches/test-1.0
+
+2. Check out the branch, if you did not create it in your own checkout.
+3. Change to the branch directory.
+4. Run the trim code to create a separate datalite directory::
+
+    python -c "from desimodel.trim import trim_data; trim_data('data', 'datalite')"
+
+5. Add the datalite directory, remove data and commit::
+
+    svn add datalite
+    svn remove data
+    svn commit -m "Adding lite files"
+
+6. Rename the existing datalite directory::
+
+    svn move datalite data
+    svn commit -m "Rename datalite"

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -5,7 +5,7 @@ Testing desimodel
 Introduction
 ------------
 
-Testing desimodel is a bit tricky since most of the code involves reading
+Tests using desimodel are a bit tricky since most of the code involves reading
 data files that are not included with the git product.  In addition, the data
 files can be rather large, both individually and as a package. This document
 describes how to create lightweight test branches of the desimodel *data*
@@ -31,12 +31,19 @@ are any additional changes to the trunkk.
 How to Create a Test Branch
 ---------------------------
 
-1. Create a branch in the standard way (for clarity the full svn URLs are omitted)::
+1. Create a branch in the standard way:
 
-    svn copy trunk branches/test-1.0
+    base=https://desi.lbl.gov/svn/code/desimodel
+    svn copy $base/trunk $base/branches/test-1.0
 
 2. Check out the branch, if you did not create it in your own checkout.
+
+    svn checkout $base/branches/test-1.0
+
 3. Change to the branch directory.
+
+    cd test-1.0
+
 4. Run the trim code to create a separate datalite directory::
 
     python -c "from desimodel.trim import trim_data; trim_data('data', 'datalite')"
@@ -50,6 +57,10 @@ How to Create a Test Branch
 6. Rename the existing datalite directory::
 
     svn move datalite data
-    svn commit -m "Rename datalite"
+    svn commit -m "Rename datalite/ back to data/"
+
+7. Now tests can get this lightweight branch on-the-fly with
+
+    svn export $base/test-1.0
 
 If you find any problems, just wipe out the branch and start again.

--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -51,3 +51,5 @@ How to Create a Test Branch
 
     svn move datalite data
     svn commit -m "Rename datalite"
+
+If you find any problems, just wipe out the branch and start again.

--- a/py/desimodel/trim.py
+++ b/py/desimodel/trim.py
@@ -1,0 +1,202 @@
+#- Code for trimming desimodel/data into smaller files
+
+from __future__ import absolute_import, division, print_function
+from astropy.io.fits import HDUList, PrimaryHDU, ImageHDU, BinTableHDU
+from astropy.io import fits
+import numpy as np
+import os.path
+import shutil
+
+def trim_data(indir, outdir, clobber=False):
+    '''
+    Trim a $DESIMODEL/data directory into a lightweight version for testing
+    
+    Args:
+        indir : a $DESIMODEL/data directory from svn
+        outdir : output data directory location
+        
+    Optional:
+        clobber : if True, remove outdir if it already exists
+    '''
+    assert os.path.abspath(indir) != os.path.abspath(outdir)
+    if os.path.exists(outdir) and clobber:
+        shutil.rmtree(outdir)
+        
+    os.makedirs(outdir)
+
+    #- python note:
+    #- *inout(indir, outdir, filename) -> indir/filename, outdir/filename
+    
+    shutil.copy(*inout(indir, outdir, 'desi.yaml'))
+    trim_focalplane(*inout(indir, outdir, 'focalplane'))
+    trim_footprint(*inout(indir, outdir, 'footprint'))
+    trim_inputs(*inout(indir, outdir, 'inputs'))
+    trim_sky(*inout(indir, outdir, 'sky'))
+    trim_specpsf(*inout(indir, outdir, 'specpsf'))
+    trim_spectra(*inout(indir, outdir, 'spectra'))
+    trim_targets(*inout(indir, outdir, 'targets'))
+    trim_throughput(*inout(indir, outdir, 'throughput'))
+    
+def inout(indir, outdir, filename):
+    '''returns os.path.join(indir, filename) and .join(outdir, filename)'''
+    infile = os.path.join(indir, filename)
+    outfile = os.path.join(outdir, filename)
+    return infile, outfile
+
+def trim_focalplane(indir, outdir):
+    '''copy everything in focalplane'''
+    assert os.path.basename(indir) == 'focalplane'
+    shutil.copytree(indir, outdir)
+
+def trim_footprint(indir, outdir):
+    '''Copies subset of desi-tiles.fits but not desi-tiles.par'''
+    assert os.path.basename(indir) == 'footprint'
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+    infile, outfile = inout(indir, outdir, 'desi-tiles.fits')
+    t = fits.getdata(infile)
+    ii = (110 < t.RA) & (t.RA < 140) & (-10 < t.DEC) & (t.DEC < 20)
+    fits.writeto(outfile, t[ii])
+
+def trim_inputs(indir, outdir):
+    '''Don't copy any inputs'''
+    pass
+
+def trim_sky(indir, outdir):
+    '''don't copy any sky files; maybe they shouldn't be in desimodel anyway'''
+    pass
+
+def trim_specpsf(indir, outdir):
+    '''trim specpsf files to be much smaller'''
+    assert os.path.basename(indir) == 'specpsf'
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+    trim_quickpsf(indir, outdir, 'psf-quicksim.fits')
+    trim_psf(indir, outdir, 'psf-b.fits')
+    trim_psf(indir, outdir, 'psf-r.fits')
+    trim_psf(indir, outdir, 'psf-z.fits')
+
+def trim_spectra(indir, outdir):
+    '''downsample spectra, and only a few of them'''
+    assert os.path.basename(indir) == 'spectra'
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+    for filename in (
+        'spec-ABmag22.0.dat',
+        'spec-elg-o2flux-8e-17-average-line-ratios.dat',
+        'spec-lrg-z0.8-zmag20.38.dat',
+        'spec-qso-z1.5-rmag22.81.dat',
+        'spec-sky.dat',
+        'spec-sky-grey.dat',
+        'spec-sky-bright.dat',
+        ):
+        i = 0
+        fx = open(os.path.join(outdir, filename), 'w')
+        for line in open(os.path.join(indir, filename)):
+            if line.startswith('#'):
+                fx.write(line)
+            elif i%20 == 0:
+                fx.write(line)
+            i += 1
+        fx.close()
+
+def trim_targets(indir, outdir):
+    '''copy everything in targets/'''
+    assert os.path.basename(indir) == 'targets'
+    shutil.copytree(indir, outdir)
+
+def trim_throughput(indir, outdir):
+    '''downsample throughput files'''
+    assert os.path.basename(indir) == 'throughput'
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+    for filename in ['thru-b.fits', 'thru-r.fits', 'thru-z.fits']:
+        fx = fits.open(indir+'/'+filename)
+        hdus = HDUList()
+        hdus.append(fx[0])
+        hdus.append(BinTableHDU(fx[1].data[::20], header=fx[1].header))
+        hdus.append(BinTableHDU(fx[2].data[::20], header=fx[2].header))
+        hdus.writeto(outdir+'/'+filename)
+        fx.close()
+
+#-------------------------------------------------------------------------
+#- Triming PSF files
+
+def rebin_image(image, n):
+    """
+    rebin 2D array pix into bins of size n x n
+
+    New binsize must be evenly divisible into original pix image
+    """
+    assert image.shape[0] % n == 0
+    assert image.shape[1] % n == 0
+
+    s = image.shape[0]//n, n, image.shape[1]//n, n
+    return image.reshape(s).sum(-1).sum(1)
+
+def trim_psf(indir, outdir, filename):
+    assert os.path.abspath(indir) != os.path.abspath(outdir)
+    infile = os.path.join(indir, filename)
+    outfile = os.path.join(outdir, filename)
+    
+    fx = fits.open(infile)
+    hdus = HDUList()
+    
+    #- HDU 0 XCOEFF - data unchanged but update keywords for less samples
+    xcoeff = fx[0].data
+    hdr = fx[0].header
+    hdr['NWAVE'] = 3    #- down from 11
+    hdr['CRPIX1'] = 23  #- 23=45//2+1, down from 113=225//2+1
+    hdr['CRPIX1'] = 23
+    hdr['CDELT1'] = 0.005   #- 5mm instead of 1mm
+    hdr['CDELT2'] = 0.005   #- 5mm instead of 1mm
+    hdr['PIXSIZE'] = 0.005   #- 5mm instead of 1mm
+    
+    hdus.append(PrimaryHDU(xcoeff, header=hdr))
+    hdus.append(fx['YCOEFF'])
+
+    #- subsample spots
+    inspots = fx['SPOTS'].data
+    spots = np.zeros((3,3,45,45))
+    spots[0,0] = rebin_image(inspots[0,0], 5)
+    spots[1,0] = rebin_image(inspots[5,0], 5)
+    spots[2,0] = rebin_image(inspots[10,0], 5)
+    spots[0,1] = rebin_image(inspots[0,5], 5)
+    spots[1,1] = rebin_image(inspots[5,5], 5)
+    spots[2,1] = rebin_image(inspots[10,5], 5)
+    spots[0,2] = rebin_image(inspots[0,10], 5)
+    spots[1,2] = rebin_image(inspots[5,10], 5)
+    spots[2,2] = rebin_image(inspots[10,10], 5)
+    hdus.append(ImageHDU(spots, header=fx['SPOTS'].header))
+    
+    #- subsample spots x,y locations
+    dx = fx['SPOTX'].data
+    hdus.append(ImageHDU(dx[::5, ::5], header=fx['SPOTX'].header))
+    dy = fx['SPOTY'].data
+    hdus.append(ImageHDU(dy[::5, ::5], header=fx['SPOTY'].header))
+    
+    #- Fiberpos unchanged
+    hdus.append(fx['FIBERPOS'])
+    
+    #- Subsample SPOTPOS and SPOTWAVE
+    d = fx['SPOTPOS'].data
+    hdus.append(ImageHDU(d[::5], header=fx['SPOTPOS'].header))
+    d = fx['SPOTWAVE'].data
+    hdus.append(ImageHDU(d[::5], header=fx['SPOTWAVE'].header))
+    
+    hdus.writeto(outfile, clobber=True)
+    fx.close()
+    
+def trim_quickpsf(indir, outdir, filename):
+    assert os.path.abspath(indir) != os.path.abspath(outdir)
+    infile = os.path.join(indir, filename)
+    outfile = os.path.join(outdir, filename)
+    fx = fits.open(infile)
+    hdus = HDUList()
+    hdus.append(fx[0])
+    for i in [1,2,3]:
+        d = fx[i].data
+        hdus.append(BinTableHDU(d[::10], header=fx[i].header))
+    hdus.writeto(outfile, clobber=True)
+    fx.close()
+


### PR DESCRIPTION
This PR provides `desimodel.trim.trim_data(indir, outdir)` as a utility function for converting a full desimodel/data directory into a lightweight one that can be quickly downloaded for testing, e.g. with travis.  See doc/testing.rst for a description of how to make a testing branch tag using this.