### PR TITLE
Generalize data install script for desiInstall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ env:
         - DESIUTIL_VERSION=1.3.2
         - SPECTER_VERSION=0.3
         # This is the version of the svn data product to export.
-        - DESIMODEL_VERSION=trunk
+        - DESIMODEL_VERSION=branches/test-0.4
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
@@ -117,7 +117,7 @@ install:
     # egg_info causes the astropy/ci-helpers script to exit before the pip
     # packages are installed, thus desiutil is not installed in that script.
     - for p in $DESIHUB_PIP_DEPENDENCIES; do r=$(echo $p | cut -d= -f1); v=$(echo $p | cut -d= -f2); pip install git+https://github.com/desihub/${r}.git@${v}#egg=${r}; done
-    - if [[ $SETUP_CMD == test* ]]; then source etc/travis_desimodel_data.sh; fi
+    - if [[ $SETUP_CMD == test* ]]; then source etc/desimodel_data.sh; fi
 
 script:
     - $MAIN_CMD $SETUP_CMD

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -2,10 +2,11 @@
 desimodel Release Notes
 =======================
 
-0.5.0 (unreleased)
+0.4.4 (2016-03-15)
 ------------------
 
 * Allow desiInstall to download and install the data from svn.
+* No changes to data in svn.
 
 0.4.3 (2016-03-10)
 ------------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,15 +5,16 @@ desimodel Release Notes
 0.5.0 (unreleased)
 ------------------
 
+* Allow desiInstall to download and install the data from svn.
+
 0.4.3 (2016-03-10)
 ------------------
 
 * "First" post-separation tag.
-* Add code to create trimmed versions of the data.
 * Added desimodel.trim.trim_data for trimming a data directory into a
-  lightweight version for testing
+  lightweight version for testing.
 * svn data includes targets.dat preliminary numbers for MWS and BGS densities
-  (Still waiting upon supporting technote)
+  (Still waiting upon supporting technote).
 
 0.4.2 (2016-02-04)
 ------------------

--- a/etc/desimodel_data.sh
+++ b/etc/desimodel_data.sh
@@ -1,4 +1,23 @@
 #!/bin/bash -x
 set -e
+#
+# If this script is being run by Travis, the Travis install script will
+# already be in the correct directory.
+# If this script is being run by desiInstall, then we need to make sure
+# we are running this in ${WORKING_DIR}.
+#
+[[ -n "${WORKING_DIR}" ]] && cd ${WORKING_DIR}
+#
+# Make sure DESIMODEL_VERSION is set.
+#
+if [[ -z "${DESIMODEL_VERSION}" ]]; then
+    echo "DESIMODEL_VERSION is not set!"
+    exit 1
+fi
 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_VERSION}/data
+#
+# Set this for subsequent Travis tests.  For desiInstall, this environment
+# variable should already be set when the desimodel Module file is
+# processed.
+#
 [[ -z "${DESIMODEL}" ]] && export DESIMODEL=$(pwd)

--- a/etc/desimodel_data.sh
+++ b/etc/desimodel_data.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -x
+set -e
+svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_VERSION}/data
+[[ -z "${DESIMODEL}" ]] && export DESIMODEL=$(pwd)

--- a/etc/travis_desimodel_data.sh
+++ b/etc/travis_desimodel_data.sh
@@ -1,6 +1,0 @@
-#!/bin/bash -x
-set -e
-export DESIMODEL=${HOME}/desimodel/${DESIMODEL_VERSION}
-mkdir -p ${DESIMODEL}
-# Do this in a subshell, so the directory change doesn't affect the main script.
-(cd ${DESIMODEL} && svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_VERSION}/data)


### PR DESCRIPTION
Fixes #11.

Previously, desimodel had a special afterburner script to install the data in svn for tests.  This has now been generalized to support both Travis and desiInstall.
