### PR TITLE
More robust scripted download of data

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,8 @@ desimodel Release Notes
 
 * Moved test of focalplane code into the actual test suite.
 * Preparing for Python 3.
+* Changed default svn version to trunk and added error handling to
+  install_desimodel_data.
 
 0.4.5 (2016-07-15)
 ------------------

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -40,7 +40,7 @@ def svn_export(desimodel_version=None):
     from . import __version__ as this_version
     if desimodel_version is None:
         export_version = 'trunk'
-    elif 'branches/' in desimodel_version:
+    elif desimodel_version is 'truck' or 'branches/' in desimodel_version:
         export_version = desimodel_version
     else:
         export_version = 'tags/' + desimodel_version

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -44,9 +44,10 @@ def svn_export(desimodel_version=None):
         desimodel_version = this_version
         version_path = this_version.split('.')
         if len(version_path) < 3:
-            # Ignore any devNN suffix.
+            # We expect at least A.B.C and possibly A.B.C.D.
             raise RuntimeError('Unable to interpret version string {0}.'
                                .format(this_version))
+        # Ignore any devNN suffix.
         desimodel_version = '.'.join(version_path[:3])
     if (desimodel_version in ('trunk', 'master') or
         'branches/' in desimodel_version):

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -40,7 +40,7 @@ def svn_export(desimodel_version=None):
     from . import __version__ as this_version
     if desimodel_version is None:
         export_version = 'trunk'
-    elif desimodel_version is 'truck' or 'branches/' in desimodel_version:
+    elif desimodel_version is 'trunk' or 'branches/' in desimodel_version:
         export_version = desimodel_version
     else:
         export_version = 'tags/' + desimodel_version

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -28,7 +28,7 @@ def svn_export(desimodel_version=None):
     Parameters
     ----------
     desimodel_version : :class:`str`, optional
-        The version to download or one of: trunk, master, or something of the
+        The version X.Y.Z to download, trunk, or something of the
         form branches/... Defaults to trunk.
 
     Returns
@@ -39,9 +39,8 @@ def svn_export(desimodel_version=None):
     """
     from . import __version__ as this_version
     if desimodel_version is None:
-        desimodel_version = 'trunk'
-    if (desimodel_version in ('trunk', 'master') or
-        'branches/' in desimodel_version):
+        export_version = 'trunk'
+    elif 'branches/' in desimodel_version:
         export_version = desimodel_version
     else:
         export_version = 'tags/' + desimodel_version

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -28,10 +28,8 @@ def svn_export(desimodel_version=None):
     Parameters
     ----------
     desimodel_version : :class:`str`, optional
-        The version to download.  If not provided, a best guess at the latest
-        tag of the package itself will be used, which is based on the current
-        package version with any .devNN suffix removed. Instead of a tag,
-        you can specify trunk, master, or something of the form branches/...
+        The version to download or one of: trunk, master, or something of the
+        form branches/... Defaults to trunk.
 
     Returns
     -------
@@ -41,14 +39,7 @@ def svn_export(desimodel_version=None):
     """
     from . import __version__ as this_version
     if desimodel_version is None:
-        desimodel_version = this_version
-        version_path = this_version.split('.')
-        if len(version_path) < 3:
-            # We expect at least A.B.C and possibly A.B.C.D.
-            raise RuntimeError('Unable to interpret version string {0}.'
-                               .format(this_version))
-        # Ignore any devNN suffix.
-        desimodel_version = '.'.join(version_path[:3])
+        desimodel_version = 'trunk'
     if (desimodel_version in ('trunk', 'master') or
         'branches/' in desimodel_version):
         export_version = desimodel_version
@@ -132,7 +123,7 @@ If the data directory already exists, this script will not do anything.
                         help='Explicitly set the version to download.')
     options = parser.parse_args()
     try:
-        status = install(options.desimodel, options.desimodel_version)
+        install(options.desimodel, options.desimodel_version)
     except (ValueError, RuntimeError) as e:
         print(e.message)
         return 1

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -24,7 +24,8 @@ class TestInstall(unittest.TestCase):
         """
         base_url = "https://desi.lbl.gov/svn/code/desimodel/{0}/data"
         cmd = svn_export()
-        self.assertEqual(cmd[2], base_url.format('tags/'+desimodel_version))
+        default_tag = '.'.join(desimodel_version.split('.')[:3])
+        self.assertEqual(cmd[2], base_url.format('tags/'+default_tag))
         cmd = svn_export('trunk')
         self.assertEqual(cmd[2], base_url.format('trunk'))
         cmd = svn_export('branches/v3')

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -24,8 +24,7 @@ class TestInstall(unittest.TestCase):
         """
         base_url = "https://desi.lbl.gov/svn/code/desimodel/{0}/data"
         cmd = svn_export()
-        default_tag = '.'.join(desimodel_version.split('.')[:3])
-        self.assertEqual(cmd[2], base_url.format('tags/'+default_tag))
+        self.assertEqual(cmd[2], base_url.format('trunk'))
         cmd = svn_export('trunk')
         self.assertEqual(cmd[2], base_url.format('trunk'))
         cmd = svn_export('branches/v3')


### PR DESCRIPTION
Running `install_desimodel_data` from the master branch fails silently because it tries to `svn export` a non-existent tag (due to a `devNN` suffix in the version string) and does not print any error message if the subprocess return code is non-zero.

This PR guesses the appropriate tag by dropping any `devNN` suffix in the version string and prints the stderr from `svn export` in case of a non-zero return code.