### PR TITLE
exclude PROGRAM=EXTRA tiles by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
         - DESIUTIL_VERSION=1.7.0
         - SPECTER_VERSION=0.6.0
         # This is the version of the svn data product to export.
-        - DESIMODEL_VERSION=branches/test-0.4.5
+        - DESIMODEL_VERSION=branches/test-0.5.1
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES='pyyaml scipy astropy'

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,8 @@ desimodel Release Notes
 0.5.1 (unreleased)
 ------------------
 
-* No changes yet
+* By default, desimodel.io.load_tiles now excludes PROGRAM=EXTRA layers
+* Adds desi-tiles.* tests
 
 0.5.0 (2016-11-21)
 ------------------

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -116,7 +116,7 @@ def load_tiles(onlydesi=True, extra=False):
 
     #- Filter out PROGRAM=EXTRA tiles if requested
     if not extra:
-        subset &= ~np.char.startswith(_tiles['PROGRAM'], 'EXTRA')
+        subset &= ~np.char.startswith(_tiles['PROGRAM'], 'EXTRA')            
 
     if np.all(subset):
         return _tiles

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -99,12 +99,15 @@ class TestIO(unittest.TestCase):
         tiles = np.zeros((4,), dtype=[('TILEID', 'i2'),
                                       ('RA', 'f8'),
                                       ('DEC', 'f8'),
-                                      ('IN_DESI', 'i2')])
-        t = tiles.view(np.recarray)
-        t.TILEID = np.arange(4) + 1
-        t.RA = [0.0, 1.0, 2.0, 3.0]
-        t.DEC = [-2.0, -1.0, 1.0, 2.0]
-        t.IN_DESI = [0, 1, 1, 0]
+                                      ('IN_DESI', 'i2'),
+                                      ('PROGRAM', (str, 6)),
+                                  ])
+        
+        tiles['TILEID'] = np.arange(4) + 1
+        tiles['RA'] = [0.0, 1.0, 2.0, 3.0]
+        tiles['DEC'] = [-2.0, -1.0, 1.0, 2.0]
+        tiles['IN_DESI'] = [0, 1, 1, 0]
+        tiles['PROGRAM'] = 'DARK'
         io._tiles = tiles
         ra, dec = io.get_tile_radec(1)
         self.assertEqual((ra, dec), (0.0, 0.0))

--- a/py/desimodel/test/test_tiles.py
+++ b/py/desimodel/test/test_tiles.py
@@ -50,11 +50,6 @@ class TestTiles(unittest.TestCase):
                 self.assertTrue(np.all(self.tf[col]==self.te[col]), 'fits[{col}] != ecsv[{col}]'.format(col=col))
 
     #- Test that PROGRAM does not have trailing white space in input files
-    #- Chicken-and-egg: test passes on desimodel svn trunk but not latest test
-    #- subset branch.  Not running test on master until we have a new subset
-    #- branch for which this would work (but that won't occur until after this
-    #- code merge and new tag...)
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping Travis test that fails on out-of-date test subset data')
     def test_program(self):
         self.assertTrue(not np.any(np.char.endswith(self.tf['PROGRAM'], ' ')))
         self.assertTrue(not np.any(np.char.endswith(self.tt['PROGRAM'], ' ')))

--- a/py/desimodel/test/test_tiles.py
+++ b/py/desimodel/test/test_tiles.py
@@ -22,21 +22,25 @@ class TestTiles(unittest.TestCase):
         self.te = Table.read(self.ecsvtiles, format='ascii.ecsv')
 
     def test_options(self):
-        a = desimodel.io.load_tiles(onlydesi=False)
-        self.assertTrue(np.any(a['IN_DESI'] == 0))
         a = desimodel.io.load_tiles(onlydesi=True)
         self.assertTrue(np.all(a['IN_DESI'] > 0))
+        b = desimodel.io.load_tiles(onlydesi=False)
+        self.assertTrue(np.any(b['IN_DESI'] == 0))
+        self.assertLess(len(a), len(b))
+        #- All tiles in DESI are also in full set
+        self.assertTrue(np.all(np.in1d(a['TILEID'], b['TILEID'])))
 
         a = desimodel.io.load_tiles(extra=False)
         self.assertEqual(np.sum(np.char.startswith(a['PROGRAM'], 'EXTRA')), 0)
-        a = desimodel.io.load_tiles(extra=True)
-        self.assertGreater(np.sum(np.char.startswith(a['PROGRAM'], 'EXTRA')), 0)
+        b = desimodel.io.load_tiles(extra=True)
+        self.assertGreater(np.sum(np.char.startswith(b['PROGRAM'], 'EXTRA')), 0)
+        self.assertLess(len(a), len(b))        
 
     #- Test consistency of FITS vs. ECSV ASCII formats, allowing for rounding
     #- differences between decimal ASCII and IEEE float32
     def test_consistency(self):
         self.assertEqual(sorted(self.tf.dtype.names), sorted(self.tt.colnames))
-        self.assertEqual(sorted(self.tf.dtype.names), sorted(self.te.colnames))        
+        self.assertEqual(sorted(self.tf.dtype.names), sorted(self.te.colnames))
 
         for col in self.tt.colnames:
             self.assertTrue(np.all(self.tf[col]==self.tt[col]), 'fits[{col}] != table[{col}]'.format(col=col))
@@ -55,6 +59,29 @@ class TestTiles(unittest.TestCase):
         self.assertTrue(not np.any(np.char.endswith(self.tf['PROGRAM'], ' ')))
         self.assertTrue(not np.any(np.char.endswith(self.tt['PROGRAM'], ' ')))
         self.assertTrue(not np.any(np.char.endswith(self.te['PROGRAM'], ' ')))
+
+    def test_get_tile_radec(self):
+        """Test grabbing tile information by tileID.
+        """
+        io_tile_cache = desimodel.io._tiles
+        tiles = np.zeros((4,), dtype=[('TILEID', 'i2'),
+                                      ('RA', 'f8'),
+                                      ('DEC', 'f8'),
+                                      ('IN_DESI', 'i2'),
+                                      ('PROGRAM', (str, 6)),
+                                  ])
+        
+        tiles['TILEID'] = np.arange(4) + 1
+        tiles['RA'] = [0.0, 1.0, 2.0, 3.0]
+        tiles['DEC'] = [-2.0, -1.0, 1.0, 2.0]
+        tiles['IN_DESI'] = [0, 1, 1, 0]
+        tiles['PROGRAM'] = 'DARK'
+        desimodel.io._tiles = tiles
+        ra, dec = desimodel.io.get_tile_radec(1)
+        self.assertEqual((ra, dec), (0.0, 0.0))
+        ra, dec, = desimodel.io.get_tile_radec(2)
+        self.assertEqual((ra, dec), (1.0, -1.0))
+        desimodel.io._tiles = io_tile_cache
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes #30 by addressing the remaining piece of excluding PROGRAM='EXTRA' tiles by default when using `desimodel.io.load_tiles()`.  Use option `extra=True` to get those extra layers back.  Note that this is different from `onlydesi=True/False` that filters on footprint (area of sky) rather than layer.

I also added some tests; one of these tests that the PROGRAM column doesn't have trailing whitespace.  This works for trunk but not for the last test data subset so it is temporarily disabled for Travis.  After this PR is reviewed and merged, we can enable that test for Travis and do a fresh set of tags.