### PR TITLE
fix tests: OBSCONDITIONS u2 or i4

### DIFF
--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -123,6 +123,11 @@ def load_tiles(onlydesi=True, extra=False):
         if any([c.bzero is not None for c in _tiles.columns]):
             foo = [_tiles[k].dtype for k in _tiles.dtype.names]
 
+        #- Check for out-of-date tiles file
+        if np.issubdtype(_tiles['OBSCONDITIONS'].dtype, 'u2'):
+            import warnings
+            warnings.warn('old desi-tiles.fits with uint16 OBSCONDITIONS; please update your $DESIMODEL checkout', DeprecationWarning)
+
     #- Filter to only the DESI footprint if requested
     subset = np.ones(len(_tiles), dtype=bool)
     if onlydesi:

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -98,8 +98,11 @@ class TestIO(unittest.TestCase):
         t2 = io.load_tiles(onlydesi=True)
         tile_cache_id2 = id(io._tiles)
         self.assertEqual(tile_cache_id1, tile_cache_id2)
-        self.assertIs(t1['OBSCONDITIONS'].dtype, np.dtype(np.uint16))
-        self.assertIs(t2['OBSCONDITIONS'].dtype, np.dtype(np.uint16))
+        #- Temporarily support OBSCONDITIONS as u2 (old) or i4 (new)
+        self.assertTrue(np.issubdtype(t1['OBSCONDITIONS'].dtype, 'i4') or \
+                        np.issubdtype(t1['OBSCONDITIONS'].dtype, 'u2') )
+        self.assertTrue(np.issubdtype(t2['OBSCONDITIONS'].dtype, 'i4') or \
+                        np.issubdtype(t2['OBSCONDITIONS'].dtype, 'u2') )
         self.assertLess(len(t2), len(t1))
         # All tiles in DESI are also in full set.
         self.assertTrue(np.all(np.in1d(t2['TILEID'], t1['TILEID'])))
@@ -108,7 +111,8 @@ class TestIO(unittest.TestCase):
         t3 = io.load_tiles(onlydesi=False)
         tile_cache_id3 = id(io._tiles)
         self.assertEqual(tile_cache_id1, tile_cache_id3)
-        self.assertIs(t3['OBSCONDITIONS'].dtype, np.dtype(np.uint16))
+        self.assertTrue(np.issubdtype(t3['OBSCONDITIONS'].dtype, 'i4') or \
+                        np.issubdtype(t3['OBSCONDITIONS'].dtype, 'u2') )
         # Check for extra tiles.
         a = io.load_tiles(extra=False)
         self.assertEqual(np.sum(np.char.startswith(a['PROGRAM'], 'EXTRA')), 0)


### PR DESCRIPTION
OBSCONDITIONS in desi-tiles.fits recently changed from uint16 (u2) to int32 (i4), but tests continued to check only for u2.  This worked for Travis because it was using branch test-0.5.1 with a desi-tiles.fits with u2, but they fail when using svn trunk.  Note: moving to i4 was purposeful to work around bugs in `astropy.io.fits.get_data()` — even if we don't use that function, fits I/O library support for unsigned integers has been problematic and we can easily avoid it in the data file itself in this case.

Rather than cut a new tag and have a strong before/after break for this, I've updated the tests to check for either u2 or i4.  After the next tag or two we can deprecate the old u2 case and eventually check for only i4 to make sure people are using a recent copy of svn desimodel/data .

Note: PR #37 commented out the failing tests; it will need to merge or rebase from master and resolve that conflict after this is merged.  I'll be offline for the next 1-2 hours, but folks can comment in the meantime if they wish.