### PR TITLE
Offsetrms

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,8 +7,8 @@ desimodel Release Notes
 
 * Add desimodel.seeing module with functions that model the expected DESI
   zenith seeing at 6355A, with an accompanying jupyter notebook.
-* Altered xy offset RMS calculation in focalplane.py to use the radial
-  projection of the 2D distribution.
+* Altered xy offset RMS calculation in focalplane.py to scale the distribution
+  RMS rather than the sample standard deviation.
 
 0.5.1 (2016-12-01)
 ------------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,8 @@ desimodel Release Notes
 
 * Add desimodel.seeing module with functions that model the expected DESI
   zenith seeing at 6355A, with an accompanying jupyter notebook.
+* Altered xy offset RMS calculation in focalplane.py to use the radial
+  projection of the 2D distribution.
 
 0.5.1 (2016-12-01)
 ------------------

--- a/py/desimodel/focalplane.py
+++ b/py/desimodel/focalplane.py
@@ -67,10 +67,8 @@ def generate_random_vector_field(rms, exponent, n, seed=None, smoothing=0.05):
     offsets = np.fft.ifft2(A)
 
     # Rescale to the specified RMS radial offset.
-    # Note that we're using the definition of RMS for the radial projection 
-    # of a 2D distribution (the 68th percentile).
-    dr = np.sqrt(offsets.real ** 2 + offsets.imag ** 2).flatten()
-    rescale = rms / np.percentile(dr, 68)
+    dr2 = (offsets.real**2 + offsets.imag**2).flatten()
+    rescale = rms / np.sqrt(np.average(dr2))
     dx = offsets.real * rescale
     dy = offsets.imag * rescale
 

--- a/py/desimodel/focalplane.py
+++ b/py/desimodel/focalplane.py
@@ -67,7 +67,10 @@ def generate_random_vector_field(rms, exponent, n, seed=None, smoothing=0.05):
     offsets = np.fft.ifft2(A)
 
     # Rescale to the specified RMS radial offset.
-    rescale = rms / np.std(np.sqrt(offsets.real ** 2 + offsets.imag ** 2))
+    # Note that we're using the definition of RMS for the radial projection 
+    # of a 2D distribution (the 68th percentile).
+    dr = np.sqrt(offsets.real ** 2 + offsets.imag ** 2).flatten()
+    rescale = rms / np.percentile(dr, 68)
     dx = offsets.real * rescale
     dy = offsets.imag * rescale
 

--- a/py/desimodel/focalplane.py
+++ b/py/desimodel/focalplane.py
@@ -67,8 +67,7 @@ def generate_random_vector_field(rms, exponent, n, seed=None, smoothing=0.05):
     offsets = np.fft.ifft2(A)
 
     # Rescale to the specified RMS radial offset.
-    dr2 = (offsets.real**2 + offsets.imag**2).flatten()
-    rescale = rms / np.sqrt(np.average(dr2))
+    rescale = rms / np.sqrt(np.var(offsets.real) + np.var(offsets.imag))
     dx = offsets.real * rescale
     dy = offsets.imag * rescale
 

--- a/py/desimodel/test/test_focalplane.py
+++ b/py/desimodel/test/test_focalplane.py
@@ -17,7 +17,7 @@ class TestFocalplane(unittest.TestCase):
         dx, dy = generate_random_centroid_offsets(1.0)
         self.assertEqual(dx.shape, dy.shape)
         dr = np.sqrt(dx**2 + dy**2)
-        self.assertAlmostEqual(np.std(dr), 1.0)
+        self.assertAlmostEqual(np.sqrt(np.average(dr**2)), 1.0)
         self.assertLess(np.max(dr), 7)
 
     def test_check_radec(self):


### PR DESCRIPTION
When looking at the output of specsim, sbailey and I noticed that randomly generated xy spot offsets in the focal plane are pretty big. We tracked this down to the generation of the random vector field in focalplane.py in desimodels.

It looks like the code uses an RMS of 10.886 um (from DESI doc-347) to scale the randomly generated lateral offset distribution of the spot. However, the master branch currently scales the RMS of the radial offset distribution to 10.886, when it seems like the correct thing to do is to scale the 68th percentile of the radial offset distribution. This is usually the right thing to do when dealing with a 2D distribution, and the choice makes quite a difference in the size of the simulated offsets (see plot below). 

I did try to go through the error budget in doc-347 with Pat Jelinsky and it's not 100% clear that all the numbers in the lateral offset table refer to radial RMS values when one digs into the source documents... So while the fix "feels right" an expert should confirm.

![offsetrms](https://cloud.githubusercontent.com/assets/7385438/24022260/a33e1f36-0a62-11e7-8151-1d02abf4df3c.png)
