### PR TITLE
Cleanup

### DIFF
--- a/bin/psf2quicksim.py
+++ b/bin/psf2quicksim.py
@@ -55,7 +55,7 @@ def quicksim_input_data(psffile, ww, ifiber=100):
     npos = len(spotpos)
     nfiber = len(fiberpos)
 
-    pixsize = float(hdr['CCDPIXSZ']) / hdr['CDELT1']
+    pixsize = int(round(float(hdr['CCDPIXSZ']) / hdr['CDELT1']))
 
     #- Measure the FWHM of the spots in x and y
     spot_fwhm_x = N.zeros((npos, nwave))
@@ -119,7 +119,7 @@ desi = yaml.load(open(os.getenv('DESIMODEL')+'/data/desi.yaml'))
 import argparse
 
 parser = argparse.ArgumentParser(usage = "%prog [options]")
-parser.add_option("-o", "--output", action='store',  help="output fits file")
+parser.add_argument("-o", "--output", action='store',  help="output fits file")
 opts = parser.parse_args()
 
 if opts.output is None:
@@ -128,7 +128,7 @@ if opts.output is None:
 clobber = True
 for camera in ('b', 'r', 'z'):
     psffile = '{}/data/specpsf/psf-{}.fits'.format(os.getenv('DESIMODEL'), camera)
-    psfsha1 = hashlib.sha1(open(psffile).read()).hexdigest()
+    psfsha1 = hashlib.sha1(open(psffile, mode='rb').read()).hexdigest()
     psfhdr = fitsio.read_header(psffile)
 
     wavemin = psfhdr['WMIN_ALL']
@@ -153,7 +153,7 @@ for camera in ('b', 'r', 'z'):
     hdr.append(dict(name='TUNIT2', value='Angstrom', comment='Wavelength dispersion FWHM [Angstrom]'))
     hdr.append(dict(name='TUNIT3', value='pixel', comment='Cross dispersion FWHM [pixel]'))
     hdr.append(dict(name='TUNIT4', value='pixel', comment='Effective number of cross-dispersion pixels'))
-    hdr.append(dict(name='TUNIT5', value='Angstrom/row', comment='Angstroms per row'))
+    hdr.append(dict(name='TUNIT5', value='Angstrom/pixel', comment='Angstroms per CCD pixel row'))
 
     extname = 'QUICKSIM-'+camera.upper()
     fitsio.write(opts.output, data, header=hdr, clobber=clobber, extname=extname)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -7,6 +7,8 @@ desimodel Release Notes
 
 * Added desimodel.footprint.tiles2pix and .pix2tiles for mapping healpix
   to DESI tiles.
+* fixed psf-quicksim.fits units to be astropy-friendly
+* added `desimodel.io.load_target_info()`
 
 0.6.0 (2017-03-27)
 ------------------

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -183,6 +183,20 @@ def load_platescale():
     _platescale = np.loadtxt(infile, usecols=[0,1,6,7], dtype=columns)
     return _platescale
 
+def load_target_info():
+    '''
+    Loads data/targets/targets.yaml and returns the nested dictionary
+
+    This is primarily syntactic sugar to avoid end users constructing
+    paths and filenames by hand (which e.g. broke when targets.dat was
+    renamed to targets.yaml)
+    '''
+    targetsfile = os.path.join(datadir(),'targets','targets.yaml')
+    with open(targetsfile) as fx:
+        data = yaml.load(fx)
+
+    return data
+
 def findfile(filename):
     '''
     Return full path to data file $DESIMODEL/data/filename

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -192,6 +192,9 @@ def load_target_info():
     renamed to targets.yaml)
     '''
     targetsfile = os.path.join(datadir(),'targets','targets.yaml')
+    if not os.path.exists(targetsfile):
+        targetsfile = os.path.join(datadir(),'targets','targets.dat')
+
     with open(targetsfile) as fx:
         data = yaml.load(fx)
 

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -100,6 +100,16 @@ class TestIO(unittest.TestCase):
         self.assertTrue(p1 is p2)  #- caching worked
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
+    def test_load_targets(self):
+        """Test loading of tile files.
+        """
+        data = io.load_target_info()
+        #- Test a few keys, but not everything
+        self.assertIn('ntarget_lrg', data.keys())
+        self.assertIn('nobs_elg', data.keys())
+        self.assertIn('success_qso', data.keys())
+
+    @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_load_tiles(self):
         """Test loading of tile files.
         """


### PR DESCRIPTION
This PR includes some minor cleanup prior to a new desimodel tag:
* fixes py3.5 bugs in `bin/psf2quicksim.py` and Angstrom/row -> Angstrom/pixel units in psf-quicksim.fits (in svn trunk) as requested by #4 
  * data agree to 1e-6 relative precision compared to earlier 2.7 generation; I didn't debug why they
     weren't exactly equal
* adds `desimodel.io.load_target_info()` as requested in #32.

I've reviewed the other open issues but am not prepared to address them with this PR.
