### PR TITLE
no desimodel.io warnings if specter isn't installed

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,6 +6,7 @@ desimodel Release Notes
 ------------------
 
 * Modified path to Lya SNR spectra files used in desi_quicklya.py, used in Lya Fisher forecast.
+* don't print warnings in desimodel.io if specter isn't installed
 
 0.7.0 (2017-06-15)
 ------------------

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -21,12 +21,12 @@ def load_throughput(channel):
     channel : {'b', 'r', 'z'}
         Spectrograph channel.
     """
-    from specter.throughput import load_throughput as specter_load_throughput    
+    import specter.throughput   
     channel = channel.lower()
     global _thru
     if channel not in _thru:
         thrufile = os.path.join(os.environ['DESIMODEL'],'data','throughput','thru-{0}.fits'.format(channel))
-        _thru[channel] = specter_load_throughput(thrufile)
+        _thru[channel] = specter.throughput.load_throughput(thrufile)
     return _thru[channel]
 #
 #
@@ -40,12 +40,12 @@ def load_psf(channel):
     channel : {'b', 'r', 'z'}
         Spectrograph channel.
     """
-    from specter.psf import load_psf as specter_load_psf
+    import specter.psf
     channel = channel.lower()
     global _psf
     if channel not in _psf:
         psffile = os.path.join(os.environ['DESIMODEL'],'data','specpsf','psf-{0}.fits'.format(channel))
-        _psf[channel] = specter_load_psf(psffile)
+        _psf[channel] = specter.psf.load_psf(psffile)
     return _psf[channel]
 #
 #

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -12,22 +12,6 @@ import yaml
 import numpy as np
 import warnings
 
-#
-#- PSF and throughput, which require specter
-#
-try:
-    from specter.throughput import load_throughput as specter_load_throughput
-except ImportError as e:
-    warnings.warn(str(e))
-    warnings.warn("Unable to import specter.throughput.load_throughput(); desimodel.io.load_throughput() won't work.")
-try:
-    from specter.psf import load_psf as specter_load_psf
-except ImportError as e:
-    warnings.warn(str(e))
-    warnings.warn("Unable to import specter.psf.load_psf(); desimodel.io.load_psf() won't work.")
-#
-#
-#
 _thru = dict()
 def load_throughput(channel):
     """Returns specter Throughput object for the given channel 'b', 'r', or 'z'.
@@ -37,6 +21,7 @@ def load_throughput(channel):
     channel : {'b', 'r', 'z'}
         Spectrograph channel.
     """
+    from specter.throughput import load_throughput as specter_load_throughput    
     channel = channel.lower()
     global _thru
     if channel not in _thru:
@@ -55,6 +40,7 @@ def load_psf(channel):
     channel : {'b', 'r', 'z'}
         Spectrograph channel.
     """
+    from specter.psf import load_psf as specter_load_psf
     channel = channel.lower()
     global _psf
     if channel not in _psf:

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -21,7 +21,7 @@ def load_throughput(channel):
     channel : {'b', 'r', 'z'}
         Spectrograph channel.
     """
-    import specter.throughput   
+    import specter.throughput
     channel = channel.lower()
     global _thru
     if channel not in _thru:


### PR DESCRIPTION
This PR removes the scary but harmless warnings from desimodel.io if specter isn't installed.  Instead of warning you ahead of time that you may someday want to install specter, it just waits until you actually call something that would have needed it (`desimodel.io.load_psf()` and the deprecated `desimodel.io.load_throughput()`)

Although this may seem less helpful, in practice people seemed disconcerted by the warnings rather than just reading them in enough detail to know that they could ignore them unless they actually needed to load a PSF.

What do you think?  Better without warnings or not?

Before, without specter installed:
```
In [1]: import desimodel.io
/Users/sbailey/desi/git/desimodel/py/desimodel/io.py:21: UserWarning: No module named 'specter'
  warnings.warn(str(e))
/Users/sbailey/desi/git/desimodel/py/desimodel/io.py:22: UserWarning: Unable to import specter.throughput.load_throughput(); desimodel.io.load_throughput() won't work.
  warnings.warn("Unable to import specter.throughput.load_throughput(); desimodel.io.load_throughput() won't work.")
/Users/sbailey/desi/git/desimodel/py/desimodel/io.py:26: UserWarning: No module named 'specter'
  warnings.warn(str(e))
/Users/sbailey/desi/git/desimodel/py/desimodel/io.py:27: UserWarning: Unable to import specter.psf.load_psf(); desimodel.io.load_psf() won't work.
  warnings.warn("Unable to import specter.psf.load_psf(); desimodel.io.load_psf() won't work.")

In [2]: psf = desimodel.io.load_psf('b')
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-2-b6160aeb7ce8> in <module>()
----> 1 psf = desimodel.io.load_psf('b')

/Users/sbailey/desi/git/desimodel/py/desimodel/io.py in load_psf(channel)
     60     if channel not in _psf:
     61         psffile = os.path.join(os.environ['DESIMODEL'],'data','specpsf','psf-{0}.fits'.format(channel))
---> 62         _psf[channel] = specter_load_psf(psffile)
     63     return _psf[channel]
     64 #

NameError: name 'specter_load_psf' is not defined
```

This PR, when specter isn't installed:
```
In [1]: import desimodel.io

In [2]: psf = desimodel.io.load_psf('b')
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-2-b6160aeb7ce8> in <module>()
----> 1 psf = desimodel.io.load_psf('b')

/Users/sbailey/desi/git/desimodel/py/desimodel/io.py in load_psf(channel)
     41         Spectrograph channel.
     42     """
---> 43     import specter.psf
     44     channel = channel.lower()
     45     global _psf

ImportError: No module named 'specter'
```

Assigning to @dkirkby since he noticed this issue enough to document it in the surveysim tutorial.