### PR TITLE
Code to integrate weights for partial HEALPixels at the fringes of the DESI footprint

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,6 +5,11 @@ desimodel Release Notes
 0.7.1 (unreleased)
 ------------------
 
+* Added `desimodel.footprint.pixweight()` in :mod:`desimodel.footprint` to create an array of what fraction
+  of every HEALPixel at a given nside overlaps the DESI footprint
+* Also added `desimodel.footprint.tiles2fracpix()` to estimate which HEALPixels overlap the footprint edges
+* Added `desimodel.io.load_pixweight()` in :mod:`desimodel.io` to load the array created by 
+  `desimodel.footprint.pixweight()` and resample it to any HEALPix nside
 * Modified path to Lya SNR spectra files used in desi_quicklya.py, used in Lya Fisher forecast.
 * Added desimodel.inputs.build_gfa_table and its helper functions to write a .ecsv file for GFA data
 * Added desimodel.io.load_gfa to return the GFA data table

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -260,10 +260,12 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, decmin=-20., decma
                  .format(len(inmask),time()-t0))
 
     #ADM find which random points in the fraction pixels are in the DESI footprint
-    log.info('Start integration over fractional pixels at edges of DESI footprint...')
+    if verbose:
+        log.info('Start integration over fractional pixels at edges of DESI footprint...')
     indesi = desimodel.footprint.is_point_in_desi(desimodel.io.load_tiles(),ra[inmask],dec[inmask])
-    log.info('...{} of the random points in fractional pixels are in DESI...t={:.1f}s'
-             .format(np.sum(indesi),time()-t0))
+    if verbose:
+        log.info('...{} of the random points in fractional pixels are in DESI...t={:.1f}s'
+                 .format(np.sum(indesi),time()-t0))
 
     #ADM assign the weights of the fractional pixels as the fraction of random points
     #ADM in the fractional pixels that are in the DESI footprint
@@ -305,7 +307,8 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, decmin=-20., decma
         hp.mollview(outdata["WEIGHT"], nest=True)
         plt.savefig(outplot)
 
-    log.info('Done...t={:.1f}s'.format(time()-t0))
+    if verbose:
+        log.info('Done...t={:.1f}s'.format(time()-t0))
 
     return outdata
 

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -201,11 +201,12 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, write=False, outpl
     weight[pix] = 1.
 
     #ADM loop through to find the "edge" (fractional) pixels, until convergence
+    if verbose:
+        log.info('Start integration around partial pixels...')
     setfracpix = set([-1])
     #ADM only have a limited range, to prevent this running forever
     for i in range(20):
         if verbose:
-            log.info('Start integration around partial pixels...')
             log.info('Trying {} pixel boundary points (step={})...t={:.1f}s'
                      .format(4*2**i,2**i,time()-t0))
         #ADM find the fractional pixels at this step

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -309,7 +309,6 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, write=False, outpl
                                'footprint','desi-healpix-weights.fits')
 
         #ADM write information indicating HEALPix setup to file header
-        from desiutil import depend
         import fitsio
         hdr = fitsio.FITSHDR()
         hdr['HPXNSIDE'] = nside

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -296,7 +296,8 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, outfile=None, outp
     #ADM in the fractional pixels that are in the DESI footprint
     allinfracpix = np.histogram(pixinmask,bins=np.arange(npix))[0][fracpix]
     desiinfracpix = np.histogram(pixinmask[np.where(indesi)],bins=np.arange(npix))[0][fracpix]
-    weight[fracpix] = desiinfracpix/allinfracpix
+    #ADM guard against integer division (for backwards-compatability with Python2)
+    weight[fracpix] = desiinfracpix.astype('float64')/allinfracpix
 
     #ADM create rec array of pixels and weights and populate it
     outdata = np.empty(npix, dtype=[('HPXPIXEL', '>i8'), ('WEIGHT', '>f4')])

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -1,4 +1,4 @@
-#- Utility functions for working with the DESI footprint
+B#- Utility functions for working with the DESI footprint
 
 import numpy as np
 import os
@@ -150,7 +150,7 @@ def tiles2fracpix(nside, step=1, tiles=None, radius=None, fact=4):
     return pix[np.where(isfracpix)]
 
 def pixweight(nside, tiles=None, radius=None, precision=0.01, decmin=-20., decmax=77., 
-              write=True, outplot=None, verbose=True):
+              write=False, outplot=None, verbose=True):
     '''
     Create a rec array of the fraction of each pixel that overlaps the passed tiles
 

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -227,28 +227,16 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, write=False, outpl
     if i == 20:
         log.warning('Integration around pixel boundaries did NOT converge!')
 
+    #ADM create a mask that is True for fractional pixels, false for all other pixels
+    mask = np.zeros(npix,bool)
+    mask[fracpix] = True
+
     #ADM find the minimum and maximum dec of interest (there's no need to populate
     #ADM declinations that lie beyond the fractional pixels with random points)
     xyzverts = hp.boundaries(nside,fracpix,nest=True)
     theta, phi = hp.vec2ang(np.hstack(xyzverts).T)
     ra, dec = np.degrees(phi), 90-np.degrees(theta)
     decmin, decmax = np.min(dec), np.max(dec)
-
-    if np.min(allinfracpix) == 0:
-        w = np.where(allinfracpix == 0)
-        theta, phi = hp.pix2ang(nside,allinfracpix[w],nest=True)
-        raout, decout = np.degrees(phi), 90 - np.degrees(theta)
-        coords = [ i for i in zip(raout,decout) ]
-        log.fatal('There are points in DESI outside of the range {} to {} degrees:'
-                  .format(decmin,decmax))
-        log.fatal('{}'.format(coords))
-
-
-    #ADM create a mask that is True for fractional pixels, false for all other pixels
-    mask = np.zeros(npix,bool)
-    mask[fracpix] = True
-
-    #ADM the extent of the sphere to populate in sin of dec-space and its area
     sindecmin, sindecmax = np.sin(np.radians(decmin)), np.sin(np.radians(decmax))
     area = 360.*np.degrees(sindecmax-sindecmin)
     if verbose:

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -163,10 +163,6 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, write=False, outpl
         precision: approximate precision at which to calculate the area of pixels
             that partially overlap the footprint in SQUARE DEGREES
             (e.g. 0.01 means precise to 0.01 sq. deg., or 36 sq. arcmin.)
-        decmin: For speed-up; a minuimum declination that is outside of the 
-            DESI footprint (degrees)
-        decmax: For speed-up; a maximum declination that is outside of the 
-            DESI footprint (degrees)
         write: if True, then write the pixel->weight array to the file
            $DESIMODEL/data/footprint/desi-healpix-weights.fits
         outplot: if a string is passed, create a plot named that string
@@ -231,8 +227,8 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, write=False, outpl
     mask = np.zeros(npix,bool)
     mask[fracpix] = True
 
-    #ADM find the minimum and maximum dec of interest (there's no need to populate
-    #ADM declinations that lie beyond the fractional pixels with random points)
+    #ADM find the minimum and maximum dec of interest (there's no need to Monte Carlo
+    #ADM integrate over declinations that lie beyond the fractional pixels)
     xyzverts = hp.boundaries(nside,fracpix,nest=True)
     theta, phi = hp.vec2ang(np.hstack(xyzverts).T)
     ra, dec = np.degrees(phi), 90-np.degrees(theta)
@@ -240,7 +236,7 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, write=False, outpl
     sindecmin, sindecmax = np.sin(np.radians(decmin)), np.sin(np.radians(decmax))
     area = 360.*np.degrees(sindecmax-sindecmin)
     if verbose:
-        log.info('Populating randoms between {:.1f} and {:.1f} degrees, an area of {:.1f} sq. deg....t={:.1f}s'
+        log.info('Populating randoms between {:.2f} and {:.2f} degrees, an area of {:.1f} sq. deg....t={:.1f}s'
                  .format(decmin,decmax,area,time()-t0))
 
     #ADM determine the required precision for the area of interest

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -307,7 +307,7 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, outfile=None, outp
         hdr['HPXNSIDE'] = nside
         hdr['HPXNEST'] = True
 
-        fitsio.write(weight, outdata, extname='PIXWEIGHTS', header=hdr, clobber=True)
+        fitsio.write(outfile, weight, extname='PIXWEIGHTS', header=hdr, clobber=True)
 
     #ADM if outplot was passed, make a plot of the final mask in Mollweide projection
     if outplot is not None:

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -1,4 +1,4 @@
-B#- Utility functions for working with the DESI footprint
+#- Utility functions for working with the DESI footprint
 
 import numpy as np
 import os

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -213,7 +213,8 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, write=False, outpl
         fracpix = desimodel.footprint.tiles2fracpix(
             nside, step=2**i, tiles=tiles, radius=radius, fact=2**8)
         if verbose:
-            log.info('...found {} fractional pixels'.format(len(fracpix)))
+            log.info('...found {} fractional pixels...t={:.1f}s'
+                     .format(len(fracpix),time()-t0))
         if set(fracpix) == setfracpix:
             break
         #ADM if we didn't converge, loop through again with the new
@@ -311,8 +312,8 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, write=False, outpl
         from desiutil import depend
         import fitsio
         hdr = fitsio.FITSHDR()
-        depend.setdep(hdr, 'HPXNSIDE', nside)
-        depend.setdep(hdr, 'HPXNEST', True)
+        hdr['HPXNSIDE'] = nside
+        hdr['HPXNEST'] = True
 
         fitsio.write(outfile, outdata, extname='PIXWEIGHTS', header=hdr, clobber=True)
 

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -201,6 +201,14 @@ def load_target_info():
 
     return data
 
+def load_pixweight(nside):
+    '''
+    Loads desimodel/data/footprint/desi-healpix-weights.fits
+
+        nside: After loading, the array will be down-sampled to the
+               passed HEALPix nside, if possible
+    '''
+
 def findfile(filename):
     '''
     Return full path to data file $DESIMODEL/data/filename

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -219,7 +219,7 @@ def load_pixweight(nside):
     
     #ADM determine the file's nside, and flag a warning if the passed nside exceeds it
     npix = len(pix)
-    truenside = hp.npix2nside(len(a))
+    truenside = hp.npix2nside(len(pix))
     if truenside < nside:
         log.warning("downsampling is fuzzy...Passed nside={}, but file {} is stored at nside={}"
                   .format(nside,pixfile,truenside))

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -201,6 +201,7 @@ class TestFootprint(unittest.TestCase):
         #ADM really they should agree to much better than 11%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
         #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
+        print(np.all(np.abs(hiresweight-loresweight)))
         self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.11))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -198,10 +198,10 @@ class TestFootprint(unittest.TestCase):
         hirespixels = partpix64*16+np.arange(16)
         hiresweight = np.mean(pixweight256[hirespixels]["WEIGHT"])
         loresweight = pixweight64[partpix64]["WEIGHT"]
-        #ADM really they should agree to much better than 10%. As "precision" is not set to be
+        #ADM really they should agree to much better than 11%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
-        #ADM I checked that at precision = 0.04 this doesn't fail after 200 attempts
-        self.assertTrue(np.abs(hiresweight-loresweight) < 0.1)
+        #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
+        self.assertTrue(np.abs(hiresweight-loresweight) < 0.11)
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -201,7 +201,7 @@ class TestFootprint(unittest.TestCase):
         #ADM really they should agree to much better than 11%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
         #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
-        self.assertTrue(np.abs(hiresweight-loresweight) < 0.11)
+        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.11))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -201,7 +201,6 @@ class TestFootprint(unittest.TestCase):
         #ADM really they should agree to much better than 11%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
         #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
-        print(np.all(np.abs(hiresweight-loresweight)))
         self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.11))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -200,7 +200,7 @@ class TestFootprint(unittest.TestCase):
         loresweight = pixweight64[partpix64]["WEIGHT"]
         #ADM really they should agree to much better than 10%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
-        #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
+        #ADM I checked that at precision = 0.04 this doesn't fail after 200 attempts
         self.assertTrue(np.abs(hiresweight-loresweight) < 0.1)
 
     @unittest.skipUnless(desimodel_available, desimodel_message)

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -183,21 +183,21 @@ class TestFootprint(unittest.TestCase):
         radius = 1.605
 
         #ADM determine the weight array for pixels at nsides of 64 and 256
-        pixweight64 = footprint.pixweight(64,tiles=tiles,radius=radius,precision=0.04,verbose=False)
-        pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.04,verbose=False)
+        pixweight64 = footprint.pixweight(64,tiles=tiles,radius=radius,precision=0.04)
+        pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.04)
         
         #ADM check that the full pixel is assigned a weight of 1 at each nside
-        self.assertTrue(np.all(pixweight64[fullpix64]["WEIGHT"]==1))
-        self.assertTrue(np.all(pixweight256[fullpix256]["WEIGHT"]==1))
+        self.assertTrue(np.all(pixweight64[fullpix64]==1))
+        self.assertTrue(np.all(pixweight256[fullpix256]==1))
 
         #ADM check that the empty pixel is assigned a weight of 0 at each nside
-        self.assertTrue(np.all(pixweight64[emptypix64]["WEIGHT"]==0))
-        self.assertTrue(np.all(pixweight256[emptypix256]["WEIGHT"]==0))
+        self.assertTrue(np.all(pixweight64[emptypix64]==0))
+        self.assertTrue(np.all(pixweight256[emptypix256]==0))
 
         #ADM check weights of partial pixels agree reasonably at different nsides
         hirespixels = partpix64*16+np.arange(16)
-        hiresweight = np.mean(pixweight256[hirespixels]["WEIGHT"])
-        loresweight = pixweight64[partpix64]["WEIGHT"]
+        hiresweight = np.mean(pixweight256[hirespixels])
+        loresweight = pixweight64[partpix64]
         #ADM really they should agree to much better than 11%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
         #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -120,6 +120,17 @@ class TestIO(unittest.TestCase):
         self.assertIn('nobs_elg', data.keys())
         self.assertIn('success_qso', data.keys())
 
+    @unittest.skip('Skip *until* the pixel weights file is in the DESIMODEL directory')
+#    @unittest.skipUnless(desimodel_available, desimodel_message)
+    def test_load_pix_file(self):
+        """Test loading of the file of HEALPixel weights.
+        """
+        nside = 16
+        pix = io.load_pixweight(nside)
+        npix = len(pix)
+        #ADM Test the length of the returned array is appropriate to the passed nside
+        self.assertEqual(npix,12*nside*nside)
+
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_load_tiles(self):
         """Test loading of tile files.


### PR DESCRIPTION
This PR Monte-Carlos the area of HEALPixels at the edges of the DESI footprint. It calculates the weight of each pixel for the entire sky (at a specified `nside`), yielding:

1. values of 0 for pixels that are fully outside of the DESI footprint
2. values of 1 for pixels that are fully inside of the DESI footprint
3. values of 0 < x < 1 for "partial" pixels that overlap the DESI footprint

Note that `(the weight) x (the area of the pixels at this nside)` yields the area in the DESI footprint for each pixel.

The pixel boundaries are used to quickly determine which pixels are partial pixels, to make the overall area integration more rapid.

The code writes a FITS file, which could potentially be stored in the `$DESIMODEL` directory for general purposes.

As an example (lower values of precision lead to more precise estimates of the areas of partial pixels):

```
from desimodel import footprint
nside = 256
pixweight256 = footprint.pixweight(nside,precision=0.005)
```

runs (on a login node) in about 4.5 minutes and calculates the weights of all partial pixels to better than ~0.8%.
