### PR TITLE
Modified radec2xy and respective unit tests as well as get_radius_mm()

### DIFF
--- a/py/desimodel/focalplane.py
+++ b/py/desimodel/focalplane.py
@@ -139,22 +139,14 @@ def get_radius_mm(theta):
     """
     import scipy.interpolate
     import desimodel.io
+    platescale = desimodel.io.load_platescale()
+    # Uses a quadratic one-dimensional interpolation to approximate the radius in degrees versus radius in mm
+    fn = scipy.interpolate.interp1d(platescale['theta'], platescale['radius'], kind = 'quadratic')
+    radius = fn(theta)
     if(np.isscalar(theta)):
-        platescale = desimodel.io.load_platescale()
-        # Uses a quadratic one-dimensional interpolation to approximate the radius in degrees versus radius in mm
-        fn = scipy.interpolate.interp1d(platescale['theta'], platescale['radius'], kind = 'quadratic')
-        radius = float(fn(theta))
-        return radius
+        return float(radius)
     else:
-        platescale = desimodel.io.load_platescale()
-        # Uses a quadratic one-dimensional interpolation to approximate the radius in degrees versus radius in mm
-        fn = scipy.interpolate.interp1d(platescale['theta'], platescale['radius'], kind = 'quadratic')
-        radius = []
-        for x in theta:
-            radius_mm = float(fn(x))
-            radius.append(radius_mm)
-        radius_array = np.array(radius)
-        return radius_array
+        return radius
 
 def get_radius_deg(x, y):
     """
@@ -265,9 +257,9 @@ def radec2xy(telra, teldec, ra, dec):
     import numpy as np
     import math
     # Inclination is 90 degrees minus the declination in degrees
-    decarray = np.array(dec)
+    dec = np.asarray(dec)
     inc = 90 - decarray
-    raarray = np.array(ra)
+    ra = np.asarray(ra)
     #inc = 90 - dec
     x0 = np.sin(np.radians(inc)) * np.cos(np.radians(raarray))
     y0 = np.sin(np.radians(inc)) * np.sin(np.radians(raarray))

--- a/py/desimodel/test/test_focalplane.py
+++ b/py/desimodel/test/test_focalplane.py
@@ -46,12 +46,16 @@ class TestFocalplane(unittest.TestCase):
         truedegree = 1.5731300326614939
         radius = get_radius_mm(1.5731300326614939)
         trueradius = 398.5010456698936
+        testradii = [1.5731300326614939, 1.5]
+        radius1 = get_radius_mm(testradii)
+        trueradius1 = [398.50104567, 378.53678987]
         self.assertAlmostEqual(truedegree, degree, 5)
         self.assertAlmostEqual(trueradius, radius, 5)
+        self.assertAlmostEqual(all(trueradius1), all(radius1), 5)
     
     def new_test_xy2radec(self):
-        """Should test the consistency between the conversion functions
-        radec2xy and xy2radec. Right now tests the accuracy of the xy2radec 
+        """Tests the consistency between the conversion functions
+        radec2xy and xy2radec. Also tests the accuracy of the xy2radec
         on particular cases.
         """
         truera = 8.927313423598427
@@ -59,7 +63,9 @@ class TestFocalplane(unittest.TestCase):
         newra, newdec = xy2radec(8.37, -10.65, -138.345, -333.179)
         self.assertEqual(truera, newra, 5)
         self.assertEqual(truedec, newdec, 5)
-    
+        x, y = radec2xy(8.37, -10.65, newra, newdec)
+        self.assertEqual(x, -138.345, 5)
+        self.assertEqual(y, -333.179, 5)
 
     def test_xy2radec(self):
         """Test the consistency between the conversion functions


### PR DESCRIPTION
Added radec2xy() to the focalplane.py code and modified it to accept vector and scalar inputs. Modified get_radius_mm() to accept scalar and vector inputs as well. Added unit tests accordingly.