### PR TITLE
enable non-standard tilesfile

### DIFF
--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -131,16 +131,18 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True):
         If ``True``, trim to just the tiles in the DESI footprint.
     extra : :class:`bool`, (default False)
         If ``True``, include extra layers with PROGRAM='EXTRA'.
-    tilesfile : (str) name of tiles file to load; or None for default
-        Without path, look in $DESIMODEL/data/footprint, otherwise load file
+    tilesfile : (str)
+        Name of tiles file to load; or None for default.
+        Without path, look in $DESIMODEL/data/footprint, otherwise load file.
     cache : :class:`bool`, (default True)
-        Use cache of tiles data
+        Use cache of tiles data.
     """
     global _tiles
 
     if tilesfile is None:
         tilesfile = 'desi-tiles.fits'
 
+    #- Check if tilesfile includes a path (absolute or relative)
     tilespath, filename = os.path.split(tilesfile)
     if tilespath == '':
         tilesfile = os.path.join(os.environ['DESIMODEL'],'data','footprint',filename)

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -122,15 +122,19 @@ def load_fiberpos():
 #
 #
 _tiles = dict()
-def load_tiles(onlydesi=True, extra=False, tilesfile='desi-tiles.fits'):
+def load_tiles(onlydesi=True, extra=False, tilesfile='desi-tiles.fits', cache=True):
     """Return DESI tiles structure from desimodel/data/footprint/desi-tiles.fits.
 
-    Options
-    -------
+    Parameters
+    ----------
     onlydesi : :class:`bool` (default True)
         If ``True``, trim to just the tiles in the DESI footprint.
     extra : :class:`bool`, (default False)
         If ``True``, include extra layers with PROGRAM='EXTRA'.
+    tilesfile : (str) name of tiles file to load
+        Without path, look in $DESIMODEL/data/footprint, otherwise load file
+    cache : :class:`bool`, (default True)
+        Use cache of tiles data
     """
     global _tiles
 
@@ -141,7 +145,7 @@ def load_tiles(onlydesi=True, extra=False, tilesfile='desi-tiles.fits'):
     #- standarize path location
     tilesfile = os.path.abspath(tilesfile)
 
-    if tilesfile in _tiles:
+    if cache and tilesfile in _tiles:
         tiledata = _tiles[tilesfile]
     else:
         with fits.open(tilesfile, memmap=False) as hdulist:
@@ -159,7 +163,8 @@ def load_tiles(onlydesi=True, extra=False, tilesfile='desi-tiles.fits'):
             warnings.warn('old desi-tiles.fits with uint16 OBSCONDITIONS; please update your $DESIMODEL checkout', DeprecationWarning)
 
         #- load cache for next time
-        _tiles[tilesfile] = tiledata
+        if cache:
+            _tiles[tilesfile] = tiledata
 
     #- Filter to only the DESI footprint if requested
     subset = np.ones(len(tiledata), dtype=bool)

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -122,7 +122,7 @@ def load_fiberpos():
 #
 #
 _tiles = dict()
-def load_tiles(onlydesi=True, extra=False, tilesfile='desi-tiles.fits', cache=True):
+def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True):
     """Return DESI tiles structure from desimodel/data/footprint/desi-tiles.fits.
 
     Parameters
@@ -131,12 +131,15 @@ def load_tiles(onlydesi=True, extra=False, tilesfile='desi-tiles.fits', cache=Tr
         If ``True``, trim to just the tiles in the DESI footprint.
     extra : :class:`bool`, (default False)
         If ``True``, include extra layers with PROGRAM='EXTRA'.
-    tilesfile : (str) name of tiles file to load
+    tilesfile : (str) name of tiles file to load; or None for default
         Without path, look in $DESIMODEL/data/footprint, otherwise load file
     cache : :class:`bool`, (default True)
         Use cache of tiles data
     """
     global _tiles
+
+    if tilesfile is None:
+        tilesfile = 'desi-tiles.fits'
 
     tilespath, filename = os.path.split(tilesfile)
     if tilespath == '':

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -22,6 +22,10 @@ class TestFootprint(unittest.TestCase):
         """Test grabbing tile information by tileID.
         """
         io_tile_cache = io._tiles
+        io._tiles = dict()
+        tx = io.load_tiles()
+        tilefile = list(io._tiles.keys())[0]
+
         tiles = np.zeros((4,), dtype=[('TILEID', 'i2'),
                                       ('RA', 'f8'),
                                       ('DEC', 'f8'),
@@ -34,7 +38,7 @@ class TestFootprint(unittest.TestCase):
         tiles['DEC'] = [-2.0, -1.0, 1.0, 2.0]
         tiles['IN_DESI'] = [0, 1, 1, 0]
         tiles['PROGRAM'] = 'DARK'
-        io._tiles = tiles
+        io._tiles[tilefile] = tiles
         ra, dec = footprint.get_tile_radec(1)
         self.assertEqual((ra, dec), (0.0, 0.0))
         ra, dec, = footprint.get_tile_radec(2)

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -2,8 +2,10 @@
 # -*- coding: utf-8 -*-
 """Test desimodel.io.
 """
-import os, sys
+import os
+import sys
 import uuid
+import tempfile
 import numpy as np
 from astropy.table import Table
 import unittest
@@ -38,14 +40,15 @@ class TestIO(unittest.TestCase):
         global specter_available, desimodel_available
         cls.specter_available = specter_available
         cls.desimodel_available = desimodel_available
-        cls.trimdir = 'test-'+uuid.uuid4().hex
-        cls.testfile = 'test-'+uuid.uuid4().hex+'.fits'
+        cls.tempdir = tempfile.mkdtemp(prefix='testio-')
+        cls.trimdir = os.path.join(cls.tempdir, 'trim')
+        cls.testfile = os.path.join(cls.tempdir, 'test-abc123.fits')
 
     @classmethod
     def tearDownClass(cls):
-        if os.path.exists(cls.trimdir):
+        if os.path.exists(cls.tempdir):
             import shutil
-            shutil.rmtree(cls.trimdir)
+            shutil.rmtree(cls.tempdir)
 
     def setUp(self):
         """Ensure that any desimodel.io caches are clear before running
@@ -182,13 +185,13 @@ class TestIO(unittest.TestCase):
         #- no path; should fail since that file isn't in $DESIMODEL/data/footprint/
         if sys.version_info.major == 2:
             with self.assertRaises(IOError):
-                t2 = io.load_tiles(tilesfile=self.testfile)
+                t2 = io.load_tiles(tilesfile=os.path.basename(self.testfile))
         else:
             with self.assertRaises(FileNotFoundError):
-                t2 = io.load_tiles(tilesfile=self.testfile)
+                t2 = io.load_tiles(tilesfile=os.path.basename(self.testfile))
 
         #- with path, should work:
-        t2 = Table(io.load_tiles(tilesfile='./'+self.testfile))
+        t2 = Table(io.load_tiles(tilesfile=self.testfile))
         self.assertTrue(np.all(t1 == t2))
 
         #- cache should have two items now

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -146,7 +146,7 @@ class TestIO(unittest.TestCase):
         t1 = io.load_tiles(onlydesi=False)
         self.assertEqual(len(io._tiles), 1)
         tile_cache_id1 = id(list(io._tiles.items())[0])
-        # reloading, even with a filter, shoudln't change cache
+        # reloading, even with a filter, shouldn't change cache
         t2 = io.load_tiles(onlydesi=True)
         self.assertEqual(len(io._tiles), 1)
         tile_cache_id2 = id(list(io._tiles.items())[0])

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -138,12 +138,18 @@ class _TestIO(unittest.TestCase):
     def test_load_tiles(self):
         """Test loading of tile files.
         """
+        # starting clean
         self.assertEqual(io._tiles, {})
+        t0 = io.load_tiles(cache=False)
+        self.assertEqual(len(io._tiles), 0)
+        # loading tiles fills the cache with one items
         t1 = io.load_tiles(onlydesi=False)
-        tile_cache_id1 = id(io._tiles)
-        self.assertIsNotNone(io._tiles)
+        self.assertEqual(len(io._tiles), 1)
+        tile_cache_id1 = id(list(io._tiles.items())[0])
+        # reloading, even with a filter, shoudln't change cache
         t2 = io.load_tiles(onlydesi=True)
-        tile_cache_id2 = id(io._tiles)
+        self.assertEqual(len(io._tiles), 1)
+        tile_cache_id2 = id(list(io._tiles.items())[0])
         self.assertEqual(tile_cache_id1, tile_cache_id2)
         #- Temporarily support OBSCONDITIONS as u2 (old) or i4 (new)
         self.assertTrue(np.issubdtype(t1['OBSCONDITIONS'].dtype, 'i4') or \
@@ -156,7 +162,7 @@ class _TestIO(unittest.TestCase):
         # I think this is the exact same test as above, except using set theory.
         self.assertEqual(len(set(t2.TILEID) - set(t1.TILEID)), 0)
         t3 = io.load_tiles(onlydesi=False)
-        tile_cache_id3 = id(io._tiles)
+        tile_cache_id3 = id(list(io._tiles.items())[0])
         self.assertEqual(tile_cache_id1, tile_cache_id3)
         self.assertTrue(np.issubdtype(t3['OBSCONDITIONS'].dtype, 'i4') or \
                         np.issubdtype(t3['OBSCONDITIONS'].dtype, 'u2') )
@@ -169,6 +175,8 @@ class _TestIO(unittest.TestCase):
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_load_tiles_alt(self):
+        # starting clean
+        self.assertEqual(io._tiles, {})
         t1 = Table(io.load_tiles())
         t1.write(self.testfile)
         #- no path; should fail since that file isn't in $DESIMODEL/data/footprint/
@@ -178,6 +186,9 @@ class _TestIO(unittest.TestCase):
         #- with path, should work:
         t2 = Table(io.load_tiles(tilesfile='./'+self.testfile))
         self.assertTrue(np.all(t1 == t2))
+
+        #- cache should have two items now
+        self.assertEqual(len(io._tiles), 2)
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_tiles_consistency(self):

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -30,7 +30,7 @@ except KeyError:
     specter_message = desimodel_message
 
 
-class _TestIO(unittest.TestCase):
+class TestIO(unittest.TestCase):
     """Test desimodel.io.
     """
     @classmethod

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """Test desimodel.io.
 """
-import os
+import os, sys
 import uuid
 import numpy as np
 from astropy.table import Table
@@ -180,8 +180,12 @@ class TestIO(unittest.TestCase):
         t1 = Table(io.load_tiles())
         t1.write(self.testfile)
         #- no path; should fail since that file isn't in $DESIMODEL/data/footprint/
-        with self.assertRaises(FileNotFoundError):
-            t2 = io.load_tiles(tilesfile=self.testfile)
+        if sys.version_info.major == 2:
+            with self.assertRaises(IOError):
+                t2 = io.load_tiles(tilesfile=self.testfile)
+        else:
+            with self.assertRaises(FileNotFoundError):
+                t2 = io.load_tiles(tilesfile=self.testfile)
 
         #- with path, should work:
         t2 = Table(io.load_tiles(tilesfile='./'+self.testfile))


### PR DESCRIPTION
This PR fixes #63 to enable loading non-standard tiles files via the `desimodel.io.load_tiles` interface, albeit with a slightly different API:
```python
def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True):
    """Return DESI tiles structure from desimodel/data/footprint/desi-tiles.fits.

    Parameters
    ----------
    onlydesi : :class:`bool` (default True)
        If ``True``, trim to just the tiles in the DESI footprint.
    extra : :class:`bool`, (default False)
        If ``True``, include extra layers with PROGRAM='EXTRA'.
    tilesfile : (str) name of tiles file to load; or None for default
        Without path, look in $DESIMODEL/data/footprint, otherwise load file
    cache : :class:`bool`, (default True)
        Use cache of tiles data
    """
```
i.e. 3 cases for `tilesfiles`:
* None: use default tiles file; handy for client code that wants to have an command line option for overriding the default tiles file without wanting to hard code that the current default in desimodel is called "desi-tiles.fits"
* filename including an absolute or relative path: load that file
* bare filename not including a path: look for a file of that name in $DESIMODEL/data/footprint.

Note: Use './desi-tiles.fits' to load a file in the pwd instead of $DESIMODEL/data/footprint/desi-tiles.fits .

Implementation note: the `_tiles` cache is now a dictionary keyed by the absolute path of the files that were loaded, enabling caching more than one file and distinguishing whether the requested file is in the cache or not.  This change resulted in this PR touching more lines of code than I had originally expected.