### PR TITLE
Trimtest

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -2,16 +2,16 @@
 desimodel Release Notes
 =======================
 
-0.8.1 (unreleased)
+0.9.0 (unreleased)
 ------------------
-()
+
 * Added desimodel.focalplane.radec2xy, which converts RA, Dec coordinates to x, y coordinates on the focal plane, which accepts vector inputs.
 * Added desimodel.focalplane.on_gfa() and its respective helper functions to check if a target is on a GFA of arbitrary telescope pointing
 * Added desimodel.focalplane.on_tile_gfa() to check return a list of indices of targets on a specific tile
 * Added desimodel.focalplane.get_gfa_targets() to return a table with added columns GFA_LOC and TILEID that consists of all targets on any GFA on any tile satisfying a minimum flux in the r-band. 
 * Unittests for the desimodel.focalplane functions were updated accordingly.
 * Added desimodel.footprint.find_points_in_tel_range() to return a list of indices withnin a radius of an arbitray telescope pointing, unaware of tiles (Added respective unittest)
-
+* Updates tests to work with trimmed data subset
 
 0.8.0 (2017-08-07)
 ------------------

--- a/py/desimodel/focalplane.py
+++ b/py/desimodel/focalplane.py
@@ -622,7 +622,7 @@ def on_gfa(telra, teldec, ra, dec, buffer_arcsec = 100):
             newtargetindices = np.where(targetarea < AREA_BOUNDARY)
             targetindices.extend(newtargetindices[0])
             gfaindices.extend([int(gfaid / 4)] * len(newtargetindices[0]))
-    return inrangeindices[targetindices], gfaindices
+    return inrangeindices[targetindices], np.asarray(gfaindices)
 
 def _retrieve_minimum_boundary(x_tolerance, y_tolerance):
     """

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -500,13 +500,11 @@ def find_points_radec(telra, teldec, ra, dec, radius = None):
 def get_tile_radec(tileid):
     """Return (ra, dec) in degrees for the requested tileid.
 
-    If tileid is not in DESI, return (0.0, 0.0)
-    TODO: should it raise and exception instead?
+    Raises ValueError if tileid is not in list of known tiles
     """
     tiles = io.load_tiles()
     if tileid in tiles['TILEID']:
         i = np.where(tiles['TILEID'] == tileid)[0][0]
         return tiles[i]['RA'], tiles[i]['DEC']
     else:
-        return (0.0, 0.0)
-
+        raise ValueError('Unknown tileid {}'.format(tileid))

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -209,6 +209,17 @@ def load_platescale():
     _platescale = np.loadtxt(infile, usecols=[0,1,6,7], dtype=columns)
     return _platescale
 
+def reset_cache():
+    '''Reset I/O cache'''
+    global _thru, _psf, _params, _gfa, _fiberpos, _tiles, _platescale
+    _thru = dict()
+    _psf = dict()
+    _params = None
+    _gfa = None
+    _fiberpos = None
+    _tiles = dict()
+    _platescale = None
+
 def load_target_info():
     '''
     Loads data/targets/targets.yaml and returns the nested dictionary

--- a/py/desimodel/test/test_focalplane.py
+++ b/py/desimodel/test/test_focalplane.py
@@ -113,14 +113,15 @@ class TestFocalplane(unittest.TestCase):
 
     def test_on_tile_gfa(self):
         """Tests if on_tile_gfa returns two lists as it is supposed to"""
-        tiles = np.zeros((4,), dtype=[('TILEID', 'i2'),
-                                      ('RA', 'f8'),
-                                      ('DEC', 'f8'),
-                                      ])
-        tiles['TILEID'] = np.array([23658] * 4)
-        tiles['RA'] = np.array([0.0, 1.0, 2.0, 3.0])
-        tiles['DEC'] = np.array([-2.0, -1.0, 1.0, 2.0])
-        targetindices, gfaid = on_tile_gfa(23658, tiles, 120)
+        targets = np.zeros((4,), dtype=[('TILEID', 'i2'),
+                                        ('RA', 'f8'),
+                                        ('DEC', 'f8'),
+                                        ])
+        tileid = 23658
+        targets['TILEID'] = np.array([tileid,] * 4)
+        targets['RA'] = np.array([0.0, 1.0, 2.0, 3.0])
+        targets['DEC'] = np.array([-2.0, -1.0, 1.0, 2.0])
+        targetindices, gfaid = on_tile_gfa(tileid, targets, 120)
         self.assertEqual(0, targetindices.size)
         self.assertEqual(0, gfaid.size)
         self.assertEqual(targetindices.size, gfaid.size)

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -16,16 +16,13 @@ except KeyError:
 class TestFootprint(unittest.TestCase):
     
     def setUp(self):
-        pass
+        io.reset_cache()
             
     def test_get_tile_radec(self):
         """Test grabbing tile information by tileID.
         """
-        io._tiles = dict()
         tx = io.load_tiles()
         tilefile = list(io._tiles.keys())[0]
-        io_tile_cache = io._tiles[tilefile]
-
         tiles = np.zeros((4,), dtype=[('TILEID', 'i2'),
                                       ('RA', 'f8'),
                                       ('DEC', 'f8'),
@@ -47,7 +44,6 @@ class TestFootprint(unittest.TestCase):
         #- But TILEID 2 should be there with correct redshift
         ra, dec, = footprint.get_tile_radec(2)
         self.assertEqual((ra, dec), (1.0, -1.0))
-        io._tiles[tilefile] = io_tile_cache
 
     def test_is_point_in_desi_mock(self):
         tiles = np.zeros((4,), dtype=[('TILEID', 'i2'),

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -21,10 +21,10 @@ class TestFootprint(unittest.TestCase):
     def test_get_tile_radec(self):
         """Test grabbing tile information by tileID.
         """
-        io_tile_cache = io._tiles
         io._tiles = dict()
         tx = io.load_tiles()
         tilefile = list(io._tiles.keys())[0]
+        io_tile_cache = io._tiles[tilefile]
 
         tiles = np.zeros((4,), dtype=[('TILEID', 'i2'),
                                       ('RA', 'f8'),
@@ -39,11 +39,15 @@ class TestFootprint(unittest.TestCase):
         tiles['IN_DESI'] = [0, 1, 1, 0]
         tiles['PROGRAM'] = 'DARK'
         io._tiles[tilefile] = tiles
-        ra, dec = footprint.get_tile_radec(1)
-        self.assertEqual((ra, dec), (0.0, 0.0))
+
+        #- TILEID 1 should be filtered out as not in DESI
+        with self.assertRaises(ValueError):
+            ra, dec = footprint.get_tile_radec(1)
+
+        #- But TILEID 2 should be there with correct redshift
         ra, dec, = footprint.get_tile_radec(2)
         self.assertEqual((ra, dec), (1.0, -1.0))
-        io._tiles = io_tile_cache
+        io._tiles[tilefile] = io_tile_cache
 
     def test_is_point_in_desi_mock(self):
         tiles = np.zeros((4,), dtype=[('TILEID', 'i2'),

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -54,17 +54,28 @@ class TestIO(unittest.TestCase):
         """Ensure that any desimodel.io caches are clear before running
         any test.
         """
-        io._thru = dict()
-        io._psf = dict()
-        io._params = None
-        io._gfa = None
-        io._fiberpos = None
-        io._tiles = dict()
+        io.reset_cache()
         if os.path.exists(self.testfile):
             os.remove(self.testfile)
 
     def tearDown(self):
         pass
+
+    def test_reset_cache(self):
+        """Test cache reset (two examples at least)
+        """
+        self.assertTrue(io._fiberpos is None)
+        self.assertTrue(isinstance(io._tiles, dict))
+        self.assertEqual(len(io._tiles), 0)
+        fiberpos = io.load_fiberpos()
+        tiles = io.load_tiles()
+        self.assertTrue(io._fiberpos is not None)
+        self.assertTrue(isinstance(io._tiles, dict))
+        self.assertEqual(len(io._tiles), 1)
+        io.reset_cache()
+        self.assertTrue(io._fiberpos is None)
+        self.assertTrue(isinstance(io._tiles, dict))
+        self.assertEqual(len(io._tiles), 0)
 
     @unittest.skipUnless(specter_available, specter_message)
     def test_load_throughput(self):

--- a/py/desimodel/trim.py
+++ b/py/desimodel/trim.py
@@ -62,8 +62,8 @@ def trim_footprint(indir, outdir):
     infile, outfile = inout(indir, outdir, 'desi-tiles.fits')
     with fits.open(infile) as hdulist:
         t = Table(hdulist[1].data)
-    ii = (110 < t['RA']) & (t['RA'] < 140) & (-10 < t['DEC']) & (t['DEC'] < 20)
-    # ii = (t['PROGRAM'] != 'EXTRA')
+    #- Pick a subset on edge of footprint where healpix testing is done
+    ii = (35 < t['RA']) & (t['RA'] < 55) & (-10 < t['DEC']) & (t['DEC'] < 20)
     tx = t[ii]
     tx.write(outfile, format='fits')
     tx.write(outfile.replace('.fits', '.ecsv'), format='ascii.ecsv')

--- a/py/desimodel/trim.py
+++ b/py/desimodel/trim.py
@@ -63,6 +63,7 @@ def trim_footprint(indir, outdir):
     with fits.open(infile) as hdulist:
         t = Table(hdulist[1].data)
     ii = (110 < t['RA']) & (t['RA'] < 140) & (-10 < t['DEC']) & (t['DEC'] < 20)
+    # ii = (t['PROGRAM'] != 'EXTRA')
     tx = t[ii]
     tx.write(outfile, format='fits')
     tx.write(outfile.replace('.fits', '.ecsv'), format='ascii.ecsv')


### PR DESCRIPTION
This PR updates the desimodel code and tests such that tests can now pass using the trimmed desimodel data generated with `desimodel.trim.trim_data`.

Along the way it expanded the functionality of the GFA code tests and added `desimodel.io.reset_cache` to reset the various I/O cache objects.  `reset_cache` is primarily useful for testing where you may want to override the cached value but then get back to a known state even if your test fails.