### PR TITLE
adds pass2program and program2pass

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,8 @@ desimodel Release Notes
 0.9.1 (unreleased)
 ------------------
 
-* No changes yet
+* Added desimodel.footprint.program2pass and pass2program to convert between
+  tiling integer pass number and string program name.
 
 0.9.0 (2017-09-19)
 ------------------

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -6,7 +6,9 @@ desimodel Release Notes
 ------------------
 
 * Added desimodel.footprint.program2pass and pass2program to convert between
-  tiling integer pass number and string program name.
+  tiling integer pass number and string program name (`PR#67`_).
+
+.. _`PR#67`: https://github.com/desihub/desimodel/pull/67
 
 0.9.0 (2017-09-19)
 ------------------

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -10,6 +10,46 @@ from . import __version__ as desimodel_version
 from desiutil.log import get_logger, DEBUG
 log = get_logger(DEBUG)
 
+_pass2program = None
+def pass2program(tilepass):
+    '''
+    Converts integer tile pass number to string program name.
+
+    Args:
+        tilepass: (int or int array) tiling pass number
+
+    Returns:
+        program: program name for each pass (str or list of str)
+    '''
+    global _pass2program
+    if _pass2program is None:
+        tiles = io.load_tiles()
+        _pass2program = dict(set(zip(tiles['pass'], tiles['program'])))
+    if np.isscalar(tilepass):
+        return _pass2program[tilepass]
+    else:
+        return [_pass2program[p] for p in tilepass]
+
+def program2pass(program):
+    '''
+    Convert string program name to tile passes for that program.
+
+    Args:
+        program: (str) program name, e.g. DARK, BRIGHT, or GRAY
+
+    Returns:
+        list of integer passes that cover that program
+    '''
+    tiles = io.load_tiles()
+    passes = sorted(list(set(tiles['pass'][tiles['program'] == program])))
+    if len(passes) > 0:
+        return passes
+    else:
+        known_programs = set(tiles['program'])
+        msg = 'Unknown program {}; known programs are {}'.format(
+            program, known_programs)
+        raise ValueError(msg)
+
 def radec2pix(nside, ra, dec):
     '''Convert ra,dec to nested pixel number
 

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -24,7 +24,7 @@ def pass2program(tilepass):
     global _pass2program
     if _pass2program is None:
         tiles = io.load_tiles()
-        _pass2program = dict(set(zip(tiles['pass'], tiles['program'])))
+        _pass2program = dict(set(zip(tiles['PASS'], tiles['PROGRAM'])))
     if np.isscalar(tilepass):
         return _pass2program[tilepass]
     else:
@@ -35,20 +35,32 @@ def program2pass(program):
     Convert string program name to tile passes for that program.
 
     Args:
-        program: (str) program name, e.g. DARK, BRIGHT, or GRAY
+        program: (str for str array) program name, e.g. DARK, BRIGHT, or GRAY
 
     Returns:
-        list of integer passes that cover that program
+        list of integer passes that cover that program, or list of lists
+        if input was array-like
     '''
     tiles = io.load_tiles()
-    passes = sorted(list(set(tiles['pass'][tiles['program'] == program])))
-    if len(passes) > 0:
-        return passes
+
+    if np.isscalar(program):
+        passes = sorted(list(set(tiles['PASS'][tiles['PROGRAM'] == program])))
+        if len(passes) > 0:
+            return passes
+        else:
+            known_programs = set(tiles['PROGRAM'])
+            msg = 'Unknown program {}; known programs are {}'.format(
+                program, known_programs)
+            raise ValueError(msg)
     else:
-        known_programs = set(tiles['program'])
-        msg = 'Unknown program {}; known programs are {}'.format(
-            program, known_programs)
-        raise ValueError(msg)
+        program = np.asarray(program)
+        passes = [None,] * len(program)
+        for thisprogram in np.unique(program):
+            thesepasses = program2pass(thisprogram)
+            for i in np.where(program == thisprogram)[0]:
+                passes[i] = thesepasses
+
+        return passes
 
 def radec2pix(nside, ra, dec):
     '''Convert ra,dec to nested pixel number

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -17,7 +17,42 @@ class TestFootprint(unittest.TestCase):
     
     def setUp(self):
         io.reset_cache()
-            
+
+    def test_pass2program(self):
+        '''Test footprint.pass2program(tilepass)
+        '''
+        self.assertEqual(footprint.pass2program(0), 'DARK')
+        self.assertEqual(footprint.pass2program(1), 'DARK')
+        self.assertEqual(footprint.pass2program(2), 'DARK')
+        self.assertEqual(footprint.pass2program(3), 'DARK')
+        self.assertEqual(footprint.pass2program(4), 'GRAY')
+        self.assertEqual(footprint.pass2program(5), 'BRIGHT')
+        self.assertEqual(footprint.pass2program(6), 'BRIGHT')
+        self.assertEqual(footprint.pass2program(7), 'BRIGHT')
+
+        passes = [0,1,2,3,4,5,6,7]
+        programs = ['DARK', 'DARK', 'DARK', 'DARK', 'GRAY', 'BRIGHT', 'BRIGHT', 'BRIGHT']
+        tmp = footprint.pass2program(passes)
+        self.assertEqual(tmp, programs)
+
+        tmp = footprint.pass2program(np.array(passes))
+        self.assertEqual(tmp, programs)
+
+        tmp = footprint.pass2program([0,0,1])
+        self.assertEqual(tmp, ['DARK', 'DARK', 'DARK'])
+
+        with self.assertRaises(KeyError):
+            footprint.pass2program(999)
+
+    def test_program2pass(self):
+        '''Test footprint.program2pass()
+        '''
+        self.assertEqual(footprint.program2pass('DARK'), [0,1,2,3])
+        self.assertEqual(footprint.program2pass('GRAY'), [4,])
+        self.assertEqual(footprint.program2pass('BRIGHT'), [5,6,7])
+        with self.assertRaises(ValueError):
+            footprint.program2pass('BLAT')
+
     def test_get_tile_radec(self):
         """Test grabbing tile information by tileID.
         """

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -2,6 +2,7 @@ import unittest
 import os
 
 import numpy as np
+from astropy.table import Table
 
 from .. import io
 from .. import footprint
@@ -50,8 +51,22 @@ class TestFootprint(unittest.TestCase):
         self.assertEqual(footprint.program2pass('DARK'), [0,1,2,3])
         self.assertEqual(footprint.program2pass('GRAY'), [4,])
         self.assertEqual(footprint.program2pass('BRIGHT'), [5,6,7])
+        self.assertEqual(footprint.program2pass(['DARK', 'GRAY']), [[0,1,2,3], [4,]])
+        self.assertEqual(footprint.program2pass(np.array(['DARK', 'GRAY'])),
+                                                [[0,1,2,3], [4,]])
         with self.assertRaises(ValueError):
             footprint.program2pass('BLAT')
+
+        #- confirm it works with column inputs too
+        tiles = io.load_tiles()
+        passes = footprint.program2pass(tiles['PROGRAM'])
+        self.assertEqual(len(passes), len(tiles))
+        for p in passes:
+            self.assertNotEqual(p, None)
+        passes = footprint.program2pass(Table(tiles)['PROGRAM'])
+        self.assertEqual(len(passes), len(tiles))
+        for p in passes:
+            self.assertNotEqual(p, None)
 
     def test_get_tile_radec(self):
         """Test grabbing tile information by tileID.


### PR DESCRIPTION
This PR provides `desimodel.footprint.pass2program()` and `desimodel.footprint.program2pass()` to provide the mapping between the integer pass numbers and string program names in the pre-defined tiles.  It uses the tile definition file itself to derive the mapping instead of hardcoding which pass is which program.

This PR is a followup to desihub/desisurvey#67, which hardcoded this mapping because desimodel wasn't providing it.  I'll submit a companion desisurvey PR to use this instead, while not breaking backwards compatibility.