### PR TITLE
load psf wavemin/max into params dict

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,7 @@ desimodel Release Notes
 0.9.1 (unreleased)
 ------------------
 
-* No changes yet
+* Extracts wavelength coverage from specpsf files into params dictionary.
 
 0.9.0 (2017-09-19)
 ------------------

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -63,9 +63,19 @@ def load_desiparams():
         with open(desiparamsfile) as par:
             _params = yaml.load(par)
 
-    #- for temporary backwards compability after 'exptime' -> 'exptime_dark'
-    if ('exptime' not in _params) and ('exptime_dark' in _params):
-        _params['exptime'] = _params['exptime_dark']
+        #- for temporary backwards compability after 'exptime' -> 'exptime_dark'
+        if ('exptime' not in _params) and ('exptime_dark' in _params):
+            _params['exptime'] = _params['exptime_dark']
+
+        #- Augment params with wavelength coverage from specpsf files
+        #- wavemin/max = min/max wavelength covered by *any* fiber on the CCD
+        #- wavemin/max_all = min/max wavelength covered by *all* fibers
+        for channel in ['b', 'r', 'z']:
+            hdr = fits.getheader(findfile('specpsf/psf-{}.fits'.format(channel)), 0)
+            _params['ccd'][channel]['wavemin'] = hdr['WAVEMIN']
+            _params['ccd'][channel]['wavemax'] = hdr['WAVEMAX']
+            _params['ccd'][channel]['wavemin_all'] = hdr['WMIN_ALL']
+            _params['ccd'][channel]['wavemax_all'] = hdr['WMAX_ALL']
 
     return _params
 #

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -97,6 +97,13 @@ class TestIO(unittest.TestCase):
         """
         p = io.load_desiparams()
         self.assertTrue(isinstance(p, dict))
+
+        #- Samity checks on augmented parameters
+        for channel in ['b', 'r', 'z']:
+            x = p['ccd'][channel]
+            self.assertLess(x['wavemin'], x['wavemax'])
+            self.assertLess(x['wavemin'], x['wavemin_all'])
+            self.assertGreater(x['wavemax'], x['wavemax_all'])
     
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_load_gfa(self):


### PR DESCRIPTION
This PR augments the parameters dictionary returned by `desimodel.io.load_desiparams()` to include min/max wavelength coverage for each channel b, r, z:
* params['ccd'][channel]['wavemin'] : minimum wavelength covered by any fiber
* params['ccd'][channel]['wavemax'] : maximum wavelength covered by any fiber
* params['ccd'][channel]['wavemin_all'] : minimum wavelength covered by all fibers
* params['ccd'][channel]['wavemax_all'] : maximum wavelength covered by all fibers

This enables client code to access the min/max wavelength coverage without having to do something crazy like load a full PSF or throughput file (which requires specter...) just to access these numbers.  A companion PR to desisim will enable that so that quickspectra and newexp-random will no longer require specter to be installed.

Details:  most of the parameters are loaded directly from desi.yaml, which is owned by systems engineering.  They did not want to put the wavelength coverage directly into that file, and instead they want us to derive that from the zemax data that generates the data/specpsf/psf*.fits files.  This PR respects that boundary and augments the desi parameters dictionary by extracting the data from the psf files and adds it to the desi.yaml dictionary.  Part of the point of `desimodel.io.load_desiparams` was to isolate the user from needing to know exactly where the params came from, so I think this is consistent with that -- the parameters now come from multiple files instead of just one, but the user still accesses them through a single load function.
