### PR TITLE
optionally use an input pixel weight map

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,9 @@ desimodel Release Notes
 0.9.2 (unreleased)
 ------------------
 
-* No changes yet.
+* Optionally use an input pixel weight map in io.load_pixweight (`PR#74`_).
+
+.. _`PR#74`: https://github.com/desihub/desimodel/pull/74
 
 0.9.1 (2017-11-10)
 ------------------

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -254,7 +254,6 @@ def load_pixweight(nside, pixmap=None):
         nside: after loading, the array will be resampled to the
             passed HEALPix nside
         pixmap: input pixel weight map (optional, defaults to None)
-
     '''
     import healpy as hp
 

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -262,7 +262,7 @@ def load_pixweight(nside, pixmap=None):
     '''
     import healpy as hp
 
-    if pixmap is None:
+    if pixmap is not None:
         log.debug('Using input pixel weight map of length {}.'.format(len(pixmap)))
     else:
         #ADM read in the standard pixel weights file

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -252,8 +252,9 @@ def load_pixweight(nside, pixmap=None):
     Loads desimodel/data/footprint/desi-healpix-weights.fits
 
         nside: after loading, the array will be resampled to the
-               passed HEALPix nside
-        pixmap: input pixel weight map (optional, defaults to None) 
+            passed HEALPix nside
+        pixmap: input pixel weight map (optional, defaults to None)
+
     '''
     import healpy as hp
 

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -251,9 +251,14 @@ def load_pixweight(nside, pixmap=None):
     '''
     Loads desimodel/data/footprint/desi-healpix-weights.fits
 
+    Args:
         nside: after loading, the array will be resampled to the
             passed HEALPix nside
+
+    Options:
         pixmap: input pixel weight map (optional, defaults to None)
+
+    Returns healpix weight map for the DESI footprint at the requested nside
     '''
     import healpy as hp
 

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -247,7 +247,7 @@ def load_target_info():
 
     return data
 
-def load_pixweight(nside):
+def load_pixweight(nside, pixmap=None):
     '''
     Loads desimodel/data/footprint/desi-healpix-weights.fits
 
@@ -255,20 +255,22 @@ def load_pixweight(nside):
                passed HEALPix nside
     '''
     import healpy as hp
-    #ADM read in the standard pixel weights file
-    pixfile = os.path.join(os.environ['DESIMODEL'],'data','footprint','desi-healpix-weights.fits')
-    with fits.open(pixfile) as hdulist:
-        pix = hdulist[0].data
+
+    if pixmap is None:
+        #ADM read in the standard pixel weights file
+        pixfile = os.path.join(os.environ['DESIMODEL'],'data','footprint','desi-healpix-weights.fits')
+        with fits.open(pixfile) as hdulist:
+            pixmap = hdulist[0].data
     
     #ADM determine the file's nside, and flag a warning if the passed nside exceeds it
-    npix = len(pix)
-    truenside = hp.npix2nside(len(pix))
+    npix = len(pixmap)
+    truenside = hp.npix2nside(len(pixmap))
     if truenside < nside:
         log.warning("downsampling is fuzzy...Passed nside={}, but file {} is stored at nside={}"
                   .format(nside,pixfile,truenside))
 
     #ADM resample the map
-    return hp.pixelfunc.ud_grade(pix,nside,order_in='NESTED',order_out='NESTED')
+    return hp.pixelfunc.ud_grade(pixmap,nside,order_in='NESTED',order_out='NESTED')
 
 def findfile(filename):
     '''

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -253,10 +253,13 @@ def load_pixweight(nside, pixmap=None):
 
         nside: after loading, the array will be resampled to the
                passed HEALPix nside
+        pixmap: input pixel weight map (optional, defaults to None) 
     '''
     import healpy as hp
 
-    if pixmap is None:
+    if pixmap:
+        log.debug('Using input pixel weight map of length {}.'.format(len(pixmap)))
+    else:
         #ADM read in the standard pixel weights file
         pixfile = os.path.join(os.environ['DESIMODEL'],'data','footprint','desi-healpix-weights.fits')
         with fits.open(pixfile) as hdulist:

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -257,7 +257,7 @@ def load_pixweight(nside, pixmap=None):
     '''
     import healpy as hp
 
-    if pixmap:
+    if pixmap is None:
         log.debug('Using input pixel weight map of length {}.'.format(len(pixmap)))
     else:
         #ADM read in the standard pixel weights file

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -144,8 +144,7 @@ class TestIO(unittest.TestCase):
         self.assertIn('nobs_elg', data.keys())
         self.assertIn('success_qso', data.keys())
 
-    @unittest.skip('Skip *until* the pixel weights file is in the DESIMODEL directory')
-#    @unittest.skipUnless(desimodel_available, desimodel_message)
+    @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_load_pix_file(self):
         """Test loading of the file of HEALPixel weights.
         """


### PR DESCRIPTION
Minimal PR.  

To optimize I/O in https://github.com/desihub/desitarget/pull/264, optionally pass a cached pixel weight map to `desimodel.io.load_pixweight`.