### PR TITLE
Astropy 3 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ env:
     matrix:
         - SETUP_CMD='egg_info'
         - SETUP_CMD='bdist_egg'
-        - SETUP_CMD='test' CONDA_ALL_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+        - SETUP_CMD='test' CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
 
 matrix:
     # Don't wait for allowed failures.
@@ -74,6 +74,7 @@ matrix:
           python: 3.6
           env: ASTROPY_VERSION=3.0
                SETUP_CMD='test'
+               CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
 
     include:
 
@@ -83,6 +84,7 @@ matrix:
         - os: linux
           python: 3.5
           env: SETUP_CMD='build_sphinx --warning-is-error'
+               CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
 
         # Coverage test.  Note that installing the coverage software can
         # change the set of packages installed by conda, so we do
@@ -90,11 +92,13 @@ matrix:
         - os: linux
           python: 3.5
           env: SETUP_CMD='test --coverage'
+               CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
 
         - os: linux
           python: 3.6
           env: ASTROPY_VERSION=3.0
                SETUP_CMD='test'
+               CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
 
         # - os: osx
         #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ os:
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
+# Use Ubuntu 14.04 LTS "trusty" instead of default 12.04
+dist: trusty
+
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.
 addons:
@@ -34,8 +37,8 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.9
         # - SCIPY_VERSION=0.14
-        # - ASTROPY_VERSION=1.1.1
-        # - SPHINX_VERSION=1.5
+        # - ASTROPY_VERSION=2.0.4
+        # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=1.9.9
         - SPECTER_VERSION=0.8.3
         # This is the version of the svn data product to export.
@@ -43,18 +46,18 @@ env:
         - DESIMODEL_VERSION=trunk
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
-        - CONDA_DEPENDENCIES='pyyaml scipy astropy healpy numba'
+        - CONDA_DEPENDENCIES='pyyaml scipy healpy numba fitsio'
         # These packages will only be installed if we really need them.
         - CONDA_ALL_DEPENDENCIES=''
         # These packages will always be installed.
-        - PIP_DEPENDENCIES='fitsio'
+        - PIP_DEPENDENCIES='coveralls'
         # These packages will only be installed if we really need them.
         - PIP_ALL_DEPENDENCIES=''
         # These pip packages need to be installed in a certain order, so we
         # do that separately from the astropy/ci-helpers scripts.
         - DESIHUB_PIP_DEPENDENCIES="desiutil=${DESIUTIL_VERSION} specter=${SPECTER_VERSION}"
         # Debug the Travis install process.
-        - DEBUG=True
+        - DEBUG=False
     matrix:
         - SETUP_CMD='egg_info'
         - SETUP_CMD='bdist_egg'
@@ -70,17 +73,23 @@ matrix:
 
     include:
 
-        # Check for sphinx doc build warnings - we do this first because it
-        # runs for a long time
+        # Check for sphinx doc build warnings.
+        # Note: this test is not a perfectly realistic test of ReadTheDocs
+        # builds, which operate in a much more bare-bones environment
         - os: linux
           python: 3.5
           env: SETUP_CMD='build_sphinx --warning-is-error'
-          # -w is an astropy extension
 
-        # Try all python versions with the latest numpy
+        # Coverage test.  Note that installing the coverage software can
+        # change the set of packages installed by conda, so we do
+        # separate 'test' and 'test --coverage'.
         - os: linux
           python: 3.5
           env: SETUP_CMD='test --coverage'
+
+        - os: linux
+          python: 3.6
+          env: ASTROPY_VERSION=3.0
 
         # - os: osx
         #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.9
         # - SCIPY_VERSION=0.14
-        # - ASTROPY_VERSION=2.0.4
+        - ASTROPY_VERSION=2.0.4
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=1.9.9
         - SPECTER_VERSION=0.8.3
@@ -46,11 +46,11 @@ env:
         - DESIMODEL_VERSION=trunk
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
-        - CONDA_DEPENDENCIES='pyyaml scipy healpy numba fitsio'
+        - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES=''
+        - CONDA_ALL_DEPENDENCIES='pyyaml scipy healpy numba fitsio'
         # These packages will always be installed.
-        - PIP_DEPENDENCIES='coveralls'
+        - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
         - PIP_ALL_DEPENDENCIES=''
         # These pip packages need to be installed in a certain order, so we
@@ -61,7 +61,7 @@ env:
     matrix:
         - SETUP_CMD='egg_info'
         - SETUP_CMD='bdist_egg'
-        - SETUP_CMD='test'
+        - SETUP_CMD='test' CONDA_ALL_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
 
 matrix:
     # Don't wait for allowed failures.
@@ -70,6 +70,10 @@ matrix:
     # OS X support is still experimental, so don't penalize failuures.
     allow_failures:
         - os: osx
+        - os: linux
+          python: 3.6
+          env: ASTROPY_VERSION=3.0
+               SETUP_CMD='test'
 
     include:
 
@@ -90,6 +94,7 @@ matrix:
         - os: linux
           python: 3.6
           env: ASTROPY_VERSION=3.0
+               SETUP_CMD='test'
 
         # - os: osx
         #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,7 @@
 
 import sys
 import os
-import os.path
+from importlib import import_module
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -45,7 +45,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    napoleon_extension
+    'sphinx.ext.napoleon'
 ]
 
 # Configuration for intersphinx, copied from astropy.
@@ -131,7 +131,12 @@ napoleon_include_private_with_doc = True
 # This value contains a list of modules to be mocked up. This is useful when
 # some external dependencies are not met at build time and break the
 # building process.
-autodoc_mock_imports = ['astropy', 'numpy', 'scipy', 'specter']
+autodoc_mock_imports = []
+for missing in ('astropy', 'desiutil', 'healpy', 'numpy', 'scipy', 'specter', 'yaml'):
+    try:
+        foo = import_module(missing)
+    except ImportError:
+        autodoc_mock_imports.append(missing)
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
This PR ensures that desimodel Travis tests are consistent with recent changes to desispec, desitarget, etc.:

* Tests are explicitly run against Astropy 2.
* An additional test against Astropy 3, which is allowed to fail for now.

If some one wants to review this, I'll leave it open for a day or so, but there are no code changes here, only to the .travis.yml file.