### PR TITLE
Don't assume that INSTALL_DIR exists

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,9 @@ desimodel Release Notes
 0.9.4 (unreleased)
 ------------------
 
-* No changes yet.
+* Download script will create :envvar:`INSTALL_DIR` if it doesn't exist (PR `#80`_).
+
+.. _`#80`: https://github.com/desihub/desimodel/pull/80
 
 0.9.3 (2018-03-14)
 ------------------

--- a/etc/desimodel_data.sh
+++ b/etc/desimodel_data.sh
@@ -5,7 +5,7 @@
 # If this script is being run by desiInstall, then we need to make sure
 # we are running this in ${INSTALL_DIR}.
 #
-[[ -n "${INSTALL_DIR}" ]] && cd ${INSTALL_DIR}
+[[ -n "${INSTALL_DIR}" ]] && /bin/mkdir -p ${INSTALL_DIR} && cd ${INSTALL_DIR}
 #
 # Make sure DESIMODEL_VERSION is set.
 #


### PR DESCRIPTION
This updates the data download script to create the INSTALL_DIR directory if it doesn't already exist.