### PR TITLE
Add tests for desimodel.trim and other modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='pyyaml scipy healpy numba fitsio'
+        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy healpy numba fitsio'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.

--- a/doc/update_inputs.rst
+++ b/doc/update_inputs.rst
@@ -10,7 +10,7 @@ under data/.
 Basic Setup
 ===========
 
-Make branches of both desimodel github code and svn data::
+Make branches of both desimodel GitHub code and svn data::
 
     git checkout -b update_inputs
     base=https://desi.lbl.gov/svn/code/desimodel
@@ -25,14 +25,23 @@ having to enter a password every time::
     login StephenBailey
     password NotMyRealPassword
 
+The code in :mod:`desimodel.inputs.docdb` requires `requests`_
+(for communicating with DocDB) and `xlrd`_ (for reading Microsoft Excel spreadsheets).
+Both of these are available via Anaconda.
+
+.. _`requests`: http://docs.python-requests.org/en/master/
+.. _`xlrd`: http://www.python-excel.org/
+
 Inputs to update
 ================
 
 DESI-0530-v13 Excel spreadsheet to .ecsv file for GFA locations
 —--------------------------------------------------------------
 
-This writes the .ecsv file containing the GFA data, which 
-is pulled from the "GFALocation" tab on the DESI-0530-v13 Excel spreadsheet and from rows 16-23 and columns A-I. The function build_gfa_table() writes the file in the current directory. 
+This writes the .ecsv file containing the GFA data, which
+is pulled from the "GFALocation" tab on the DESI-0530-v13 Excel spreadsheet
+and from rows 16-23 and columns A-I. The function
+:func:`~desimodel.inputs.gfa.build_gfa_table` writes the file in the current directory.
 
 ::
 
@@ -70,10 +79,9 @@ Update methodology and document how to update the following:
   * Fiber input loss calculations
   * desi.yaml
   * desimodel/data/focalplane/platescale.txt
-  * trimming the full files into a small test set (desimodel.trim)
+  * trimming the full files into a small test set (:mod:`desimodel.trim`)
   * Optical distortions
 
       * data/inputs/throughput/raytracing.txt
       * data/throughput/DESI-0347_blur.ecsv
       * data/throughput/DESI-0347_offset.ecsv
-

--- a/py/desimodel/focalplane.py
+++ b/py/desimodel/focalplane.py
@@ -20,7 +20,7 @@ from .io import load_desiparams, load_fiberpos, load_platescale, load_tiles
 # Define this here to avoid a problem with Sphinx compilation.
 try:
     default_offset = 10.886*u.um
-except TypeError:
+except TypeError:  # pragma: no cover
     default_offset = 10.886
 
 

--- a/py/desimodel/inputs/docdb.py
+++ b/py/desimodel/inputs/docdb.py
@@ -157,8 +157,9 @@ def _auth(machine='desi.lbl.gov'):
     from requests.auth import HTTPDigestAuth
     n = netrc()
     try:
-        u,foo,p = n.authenticators(machine)
-    except:
+        u, foo, p = n.authenticators(machine)
+    except TypeError:
+        # authenticators() returns None if the machine is not found.
         raise ValueError('Unable to get user/pass from $HOME/.netrc for {}'.format(machine))
 
     return HTTPDigestAuth(u,p)

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -28,9 +28,9 @@ def assert_svn_exists():
     try:
         r = check_output(['svn', '--version'])
     except OSError as e:
-        raise AssertionError("svn command is not executable. Install svn to use the install script. Original Error is %s", e.strerror)
+        raise AssertionError("svn command is not executable. Install svn to use the install script. Original Error is: '{0}'.".format(e.strerror))
     except CalledProcessError as e:
-        raise AssertionError("The svn command (%s) on this system does not work. Output is %s" % (e.cmd, e.output))
+        raise AssertionError("The svn command ({0}) on this system does not work. Output is: '{1}'.".format(e.cmd, e.output))
 
 def svn_export(desimodel_version=None):
     """Create a :command:`svn export` command suitable for downloading a

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -32,6 +32,7 @@ def assert_svn_exists():
     except CalledProcessError as e:
         raise AssertionError("The svn command ({0}) on this system does not work. Output is: '{1}'.".format(e.cmd, e.output))
 
+
 def svn_export(desimodel_version=None):
     """Create a :command:`svn export` command suitable for downloading a
     particular desimodel version.

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -113,7 +113,6 @@ def load_fiberpos():
 
         #- Temporary backwards compatibility for renamed columns
         if 'POSITIONER' in _fiberpos.colnames:
-            import warnings
             warnings.warn('old fiberpos.fits with POSITIONER column instead of LOCATION; please update your $DESIMODEL checkout', DeprecationWarning)
             _fiberpos['LOCATION'] = _fiberpos['POSITIONER']
         else:
@@ -121,7 +120,6 @@ def load_fiberpos():
 
 
         if 'SPECTROGRAPH' in _fiberpos.colnames:
-            import warnings
             warnings.warn('old fiberpos.fits with SPECTROGRAPH column instead of SPECTRO; please update your $DESIMODEL checkout', DeprecationWarning)
             _fiberpos['SPECTRO'] = _fiberpos['SPECTROGRAPH']
         else:
@@ -174,7 +172,6 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True):
 
         #- Check for out-of-date tiles file
         if np.issubdtype(tiledata['OBSCONDITIONS'].dtype, np.unsignedinteger):
-            import warnings
             warnings.warn('old desi-tiles.fits with uint16 OBSCONDITIONS; please update your $DESIMODEL checkout', DeprecationWarning)
 
         #- load cache for next time

--- a/py/desimodel/test/test_focalplane.py
+++ b/py/desimodel/test/test_focalplane.py
@@ -40,7 +40,7 @@ class TestFocalplane(unittest.TestCase):
         F.set_tele_pointing(180.0, 45.0)
         self.assertEqual(F.ra, 180.0)
         self.assertEqual(F.dec, 45.0)
-    
+
     def test_get_radius(self):
         """Tests converting x, y coordinates on the focal plane to a radius in degrees and mm
         """
@@ -54,7 +54,7 @@ class TestFocalplane(unittest.TestCase):
         self.assertAlmostEqual(truedegree, degree, 5)
         self.assertAlmostEqual(trueradius, radius, 5)
         self.assertAlmostEqual(all(trueradius1), all(radius1), 5)
-    
+
     def test_xy2radec_new(self):
         """Tests the consistency between the conversion functions
         radec2xy and xy2radec. Also tests the accuracy of the xy2radec
@@ -143,9 +143,14 @@ class TestFocalplane(unittest.TestCase):
         self.assertEqual(targetindices.size, 0)
         self.assertEqual(gfaid.size, 0)
 
+        # Test an empty table
+        gfatargets = get_gfa_targets(targets, rfluxlim=3000)
+        self.assertEqual(len(gfatargets), 0)
+
 
 def test_suite():
     """Allows testing of only this module with the command::
+
         python setup.py test -m <modulename>
     """
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -1,6 +1,9 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desimodel.footprint.
+"""
 import unittest
 import os
-
 import numpy as np
 from astropy.table import Table
 
@@ -14,13 +17,17 @@ try:
 except KeyError:
     desimodel_available = False
 
+
+
 class TestFootprint(unittest.TestCase):
-    
+    """Test desimodel.footprint.
+    """
+
     def setUp(self):
         io.reset_cache()
 
     def test_pass2program(self):
-        '''Test footprint.pass2program(tilepass)
+        '''Test footprint.pass2program().
         '''
         self.assertEqual(footprint.pass2program(0), 'DARK')
         self.assertEqual(footprint.pass2program(1), 'DARK')
@@ -46,7 +53,7 @@ class TestFootprint(unittest.TestCase):
             footprint.pass2program(999)
 
     def test_program2pass(self):
-        '''Test footprint.program2pass()
+        '''Test footprint.program2pass().
         '''
         self.assertEqual(footprint.program2pass('DARK'), [0,1,2,3])
         self.assertEqual(footprint.program2pass('GRAY'), [4,])
@@ -201,15 +208,18 @@ class TestFootprint(unittest.TestCase):
         ret = footprint.find_tiles_over_point(tiles, (0.0,), (-3.7,), radius=1.605)
         self.assertEqual(len(ret), 1)
         self.assertEqual(ret[0], [])
-    
+
     def test_find_points_radec(self):
-        """Checks if the function is successfully finding points within a certain radius of a telra and teldec"""
-        import numpy as np
-        answer = footprint.find_points_radec(0, 0, np.array([1.5, 0, 1.9, 0]), np.array([0, 1.5, 0, 1.3]))
+        """Checks if the function is successfully finding points within a certain radius of a telra and teldec.
+        """
+        answer = footprint.find_points_radec(0, 0,
+                                             np.array([1.5, 0, 1.9, 0]),
+                                             np.array([0, 1.5, 0, 1.3]))
         self.assertEqual(answer, [0, 1, 3])
 
     def test_partial_pixels(self):
-        """check weights assigned to HEALPixels that partially overlap tiles"""
+        """Check weights assigned to HEALPixels that partially overlap tiles.
+        """
         tiles = np.zeros((4,), dtype=[('TILEID', 'i2'),
                                       ('RA', 'f8'),
                                       ('DEC', 'f8'),
@@ -231,21 +241,21 @@ class TestFootprint(unittest.TestCase):
         #ADM full = footprint.pix2tiles(256,[180])
         #ADM part = footprint.pix2tiles(256,[406])
         #ADM empty = footprint.pix2tiles(256,[20])
-        #ADM to determine the tile coordinates for these pixels 
+        #ADM to determine the tile coordinates for these pixels
         #ADM (the first tile in  the array is full and the last tile is empty)
         tiles['TILEID'] = np.arange(4) + 1
         tiles['RA'] = [43.05, 47.41, 47.08, 45.38]
         tiles['DEC'] = [1.54, 3.12, 3.17, 0.0]
         tiles['IN_DESI'] = [1, 1, 1, 1]
         tiles['PROGRAM'] = 'DARK'
-        
+
         #ADM The approximate radius of DESI tiles
         radius = 1.605
 
         #ADM determine the weight array for pixels at nsides of 64 and 256
         pixweight64 = footprint.pixweight(64,tiles=tiles,radius=radius,precision=0.04)
         pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.04)
-        
+
         #ADM check that the full pixel is assigned a weight of 1 at each nside
         self.assertTrue(np.all(pixweight64[fullpix64]==1))
         self.assertTrue(np.all(pixweight256[fullpix256]==1))
@@ -265,6 +275,8 @@ class TestFootprint(unittest.TestCase):
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):
+        """Test code on actual DESI tiles.
+        """
         tiles = io.load_tiles()
         rng = np.random.RandomState(1234)
         ra = rng.uniform(0, 360, 1000)
@@ -285,9 +297,11 @@ class TestFootprint(unittest.TestCase):
 
         # Just interesting to see how many tiles overlap a random point?
         ### print(np.bincount([len(i) for i in ret]))
-                
+
+
 def test_suite():
     """Allows testing of only this module with the command::
+
         python setup.py test -m <modulename>
     """
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_inputs.py
+++ b/py/desimodel/test/test_inputs.py
@@ -4,10 +4,22 @@
 """
 import unittest
 import os
+from requests.auth import HTTPDigestAuth
 from ..inputs import docdb, fiberpos, gfa, throughput
 
-# desimodel_available = True
-# desimodel_message = "The desimodel data set was not detected."
+desimodel_available = True
+desimodel_message = "The desimodel data set was not detected."
+try:
+    spam = os.environ['DESIMODEL']
+except KeyError:
+    desimodel_available = False
+
+skipMock = False
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    # Python 2
+    skipMock = True
 
 
 class TestInputs(unittest.TestCase):
@@ -16,6 +28,27 @@ class TestInputs(unittest.TestCase):
     def setUp(self):
         pass
 
+    def test_docdb__xls_col2int(self):
+        self.assertEqual(docdb._xls_col2int('A'), 0)
+        self.assertEqual(docdb._xls_col2int('AA'), 26)
+
+    @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
+    def test_docdb__auth(self):
+        with self.assertRaises(ValueError) as e:
+            h = docdb._auth('www.example.com')
+        self.assertEqual(str(e.exception), 'Unable to get user/pass from $HOME/.netrc for www.example.com')
+        with patch('netrc.netrc') as netrc:
+            n = netrc.return_value
+            n.authenticators.return_value = ('username', 'foo', 'password')
+            h = docdb._auth('www.example.com')
+            try:
+                self.assertIsInstance(h, HTTPDigestAuth)
+            except AttributeError:
+                # Python 2
+                pass
+            n.authenticators.assert_called_with('www.example.com')
+
+    @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_build_gfa_table(self):
         gfatable = gfa.build_gfa_table('testname.ecsv')
         self.assertTrue(os.path.exists('testname.ecsv'), "Test Failed to create a valid file!")

--- a/py/desimodel/test/test_inputs.py
+++ b/py/desimodel/test/test_inputs.py
@@ -1,29 +1,30 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
+"""Test desimodel.inputs
+"""
 import unittest
 import os
+from ..inputs import docdb, fiberpos, gfa, throughput
 
-from ..inputs import gfa
+# desimodel_available = True
+# desimodel_message = "The desimodel data set was not detected."
 
-desimodel_available = True
-desimodel_message = "The desimodel data set was not detected."
 
 class TestInputs(unittest.TestCase):
     """Test desimodel.inputs
     """
     def setUp(self):
         pass
-    
+
     def test_build_gfa_table(self):
         gfatable = gfa.build_gfa_table('testname.ecsv')
-        self.assertTrue(os.path.exists('testname.ecsv'), "Test Failed to create a valid file")
+        self.assertTrue(os.path.exists('testname.ecsv'), "Test Failed to create a valid file!")
         os.remove('testname.ecsv')
-        
-        
+
+
 def test_suite():
     """Allows testing of only this module with the command::
+
         python setup.py test -m <modulename>
     """
     return unittest.defaultTestLoader.loadTestsFromName(__name__)
-    

--- a/py/desimodel/test/test_inputs.py
+++ b/py/desimodel/test/test_inputs.py
@@ -34,11 +34,12 @@ class TestInputs(unittest.TestCase):
 
     @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
     def test_docdb__auth(self):
-        with self.assertRaises(ValueError) as e:
-            h = docdb._auth('www.example.com')
-        self.assertEqual(str(e.exception), 'Unable to get user/pass from $HOME/.netrc for www.example.com')
         with patch('netrc.netrc') as netrc:
             n = netrc.return_value
+            n.authenticators.return_value = None
+            with self.assertRaises(ValueError) as e:
+                h = docdb._auth('www.example.com')
+            self.assertEqual(str(e.exception), 'Unable to get user/pass from $HOME/.netrc for www.example.com')
             n.authenticators.return_value = ('username', 'foo', 'password')
             h = docdb._auth('www.example.com')
             try:

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -74,14 +74,27 @@ class TestInstall(unittest.TestCase):
                 with self.assertRaises(ValueError) as e:
                     install(desimodel='/opt/desimodel')
                 self.assertEqual(str(e.exception), "/opt/desimodel/data already exists!")
-        exists.assert_called_with('/opt/desimodel/data')
-        with patch('desimodel.install.assert_svn_exists'):
-            with patch('os.chdir'):
-                with patch.dict('os.environ'):
-                    try:
-                        del os.environ['DESIMODEL']
-                    except KeyError:
-                        pass
+            exists.assert_called_with('/opt/desimodel/data')
+            with patch('os.path.exists') as exists:
+                exists.return_value = True
+                with self.assertRaises(ValueError) as e:
+                    install()
+                self.assertEqual(str(e.exception), "{0}/data already exists!".format(default_install_dir()))
+            exists.assert_called_with('{0}/data'.format(default_install_dir()))
+            os.environ['DESIMODEL'] = '/opt/desimodel'
+            with patch('os.path.exists') as exists:
+                exists.return_value = True
+                with self.assertRaises(ValueError) as e:
+                    install()
+                self.assertEqual(str(e.exception), "/opt/desimodel/data already exists!")
+            exists.assert_called_with('/opt/desimodel/data')
+        with patch.dict('os.environ'):
+            try:
+                del os.environ['DESIMODEL']
+            except KeyError:
+                pass
+            with patch('desimodel.install.assert_svn_exists'):
+                with patch('os.chdir'):
                     with patch('subprocess.Popen') as Popen:
                         proc = Popen.return_value
                         proc.communicate.return_value = ('Mock stdout', 'Mock stderr')

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -64,12 +64,17 @@ class TestInstall(unittest.TestCase):
     def test_install(self):
         """Test the install function.
         """
-        mock = MagicMock(return_value=True)
-        with patch('os.path.exists', mock):
-            with self.assertRaises(ValueError) as e:
-                install(desimodel='/opt/desimodel')
-            self.assertEqual(str(e.exception), "/opt/desimodel/data already exists!")
-        mock.assert_called_with('/opt/desimodel/data')
+        with patch.dict('os.environ'):
+            try:
+                del os.environ['DESIMODEL']
+            except KeyError:
+                pass
+            with patch('os.path.exists') as exists:
+                exists.return_value = True
+                with self.assertRaises(ValueError) as e:
+                    install(desimodel='/opt/desimodel')
+                self.assertEqual(str(e.exception), "/opt/desimodel/data already exists!")
+        exists.assert_called_with('/opt/desimodel/data')
         with patch('desimodel.install.assert_svn_exists'):
             with patch('os.chdir'):
                 with patch.dict('os.environ'):

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -5,7 +5,6 @@
 import os
 from subprocess import CalledProcessError
 import unittest
-from .. import __version__ as desimodel_version
 from ..install import default_install_dir, assert_svn_exists, svn_export, install
 
 skipMock = False

--- a/py/desimodel/test/test_trim.py
+++ b/py/desimodel/test/test_trim.py
@@ -21,40 +21,38 @@ class TestTrim(unittest.TestCase):
     """
 
     @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
-    @patch.multiple('desimodel.trim', trim_focalplane=DEFAULT,
-                    trim_footprint=DEFAULT, trim_inputs=DEFAULT,
-                    trim_sky=DEFAULT, trim_specpsf=DEFAULT, trim_spectra=DEFAULT,
-                    trim_targets=DEFAULT, trim_throughput=DEFAULT)
-    def test_trim_data(self, trim_focalplane, trim_footprint, trim_inputs,
-                       trim_sky, trim_specpsf, trim_spectra,
-                       trim_targets, trim_throughput):
+    def test_trim_data(self):
         """Test the trim wrapper function.
         """
-        with patch('os.path.exists') as exists:
-            exists.return_value = False
-            with patch('os.makedirs') as makedirs:
-                with patch('shutil.copy') as copy:
-                    trim_data('/in', '/out')
-        exists.assert_called_with('/out')
-        makedirs.assert_called_with('/out')
-        copy.assert_called_with('/in/desi.yaml', '/out/desi.yaml')
-        trim_focalplane.assert_called_with('/in/focalplane', '/out/focalplane')
-        trim_footprint.assert_called_with('/in/footprint', '/out/footprint')
-        trim_inputs.assert_called_with('/in/inputs', '/out/inputs')
-        trim_sky.assert_called_with('/in/sky', '/out/sky')
-        trim_specpsf.assert_called_with('/in/specpsf', '/out/specpsf')
-        trim_spectra.assert_called_with('/in/spectra', '/out/spectra')
-        trim_targets.assert_called_with('/in/targets', '/out/targets')
-        trim_throughput.assert_called_with('/in/throughput', '/out/throughput')
-        with patch('os.path.exists') as exists:
-            exists.return_value = True
-            with patch('os.makedirs') as makedirs:
-                with patch.multiple('shutil', copy=DEFAULT, rmtree=DEFAULT) as shutilmock:
-                    trim_data('/in', '/out', overwrite=True)
-        exists.assert_called_with('/out')
-        makedirs.assert_called_with('/out')
-        shutilmock['rmtree'].assert_called_with('/out')
-        shutilmock['copy'].assert_called_with('/in/desi.yaml', '/out/desi.yaml')
+        with patch.multiple('desimodel.trim', trim_focalplane=DEFAULT,
+                            trim_footprint=DEFAULT, trim_inputs=DEFAULT,
+                            trim_sky=DEFAULT, trim_specpsf=DEFAULT, trim_spectra=DEFAULT,
+                            trim_targets=DEFAULT, trim_throughput=DEFAULT) as desimodel_trim:
+            with patch('os.path.exists') as exists:
+                exists.return_value = False
+                with patch('os.makedirs') as makedirs:
+                    with patch('shutil.copy') as copy:
+                        trim_data('/in', '/out')
+            exists.assert_called_with('/out')
+            makedirs.assert_called_with('/out')
+            copy.assert_called_with('/in/desi.yaml', '/out/desi.yaml')
+            desimodel_trim['trim_focalplane'].assert_called_with('/in/focalplane', '/out/focalplane')
+            desimodel_trim['trim_footprint'].assert_called_with('/in/footprint', '/out/footprint')
+            desimodel_trim['trim_inputs'].assert_called_with('/in/inputs', '/out/inputs')
+            desimodel_trim['trim_sky'].assert_called_with('/in/sky', '/out/sky')
+            desimodel_trim['trim_specpsf'].assert_called_with('/in/specpsf', '/out/specpsf')
+            desimodel_trim['trim_spectra'].assert_called_with('/in/spectra', '/out/spectra')
+            desimodel_trim['trim_targets'].assert_called_with('/in/targets', '/out/targets')
+            desimodel_trim['trim_throughput'].assert_called_with('/in/throughput', '/out/throughput')
+            with patch('os.path.exists') as exists:
+                exists.return_value = True
+                with patch('os.makedirs') as makedirs:
+                    with patch.multiple('shutil', copy=DEFAULT, rmtree=DEFAULT) as shutilmock:
+                        trim_data('/in', '/out', overwrite=True)
+            exists.assert_called_with('/out')
+            makedirs.assert_called_with('/out')
+            shutilmock['rmtree'].assert_called_with('/out')
+            shutilmock['copy'].assert_called_with('/in/desi.yaml', '/out/desi.yaml')
 
     def test_inout(self):
         """Test pathname helper function.

--- a/py/desimodel/test/test_trim.py
+++ b/py/desimodel/test/test_trim.py
@@ -93,18 +93,18 @@ class TestTrim(unittest.TestCase):
                                         '/out/sky/solarspec.txt')
 
     @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
-    @patch.multiple('desimodel.trim', trim_quickpsf=DEFAULT, trim_psf=DEFAULT)
-    def test_trim_specpsf(self, trim_quickpsf, trim_psf):
-        with patch('os.path.exists') as exists:
-            exists.return_value = False
-            with patch('os.makedirs') as makedirs:
-                trim_specpsf('/in/specpsf', '/out/specpsf')
-        exists.assert_called_with('/out/specpsf')
-        makedirs.assert_called_with('/out/specpsf')
-        trim_quickpsf.assert_called_with('/in/specpsf', '/out/specpsf', 'psf-quicksim.fits')
-        trim_psf.assert_has_calls([call('/in/specpsf', '/out/specpsf', 'psf-b.fits'),
-                                   call('/in/specpsf', '/out/specpsf', 'psf-r.fits'),
-                                   call('/in/specpsf', '/out/specpsf', 'psf-z.fits')])
+    def test_trim_specpsf(self):
+        with patch.multiple('desimodel.trim', trim_quickpsf=DEFAULT, trim_psf=DEFAULT) as desimodel_trim:
+            with patch('os.path.exists') as exists:
+                exists.return_value = False
+                with patch('os.makedirs') as makedirs:
+                    trim_specpsf('/in/specpsf', '/out/specpsf')
+            exists.assert_called_with('/out/specpsf')
+            makedirs.assert_called_with('/out/specpsf')
+            desimodel_trim['trim_quickpsf'].assert_called_with('/in/specpsf', '/out/specpsf', 'psf-quicksim.fits')
+            desimodel_trim['trim_psf'].assert_has_calls([call('/in/specpsf', '/out/specpsf', 'psf-b.fits'),
+                                                         call('/in/specpsf', '/out/specpsf', 'psf-r.fits'),
+                                                         call('/in/specpsf', '/out/specpsf', 'psf-z.fits')])
 
     @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
     def test_trim_targets(self):

--- a/py/desimodel/test/test_trim.py
+++ b/py/desimodel/test/test_trim.py
@@ -2,10 +2,18 @@
 # -*- coding: utf-8 -*-
 """Test desimodel.trim.
 """
+import unittest
 from os.path import abspath, dirname
 import numpy as np
-import unittest
-from ..trim import inout, rebin_image
+from ..trim import (inout, rebin_image, trim_focalplane, trim_inputs,
+                    trim_sky, trim_targets)
+
+skipMock = False
+try:
+    from unittest.mock import patch, MagicMock
+except ImportError:
+    # Python 2
+    skipMock = True
 
 
 class TestTrim(unittest.TestCase):
@@ -26,9 +34,42 @@ class TestTrim(unittest.TestCase):
         i2 = np.array([[25, 25], [25, 25]], dtype='i2')
         self.assertTrue((i1 == i2).all())
 
+    @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
+    def test_trim_focalplane(self):
+        """Test trim_focalplane().
+        """
+        with patch('shutil.copytree') as copytree:
+            trim_focalplane('/in/focalplane', '/out/focalplane')
+            copytree.assert_called_with('/in/focalplane', '/out/focalplane')
+
+    def test_trim_inputs(self):
+        """Test trim_inputs().
+        """
+        # This function does nothing, so we just check that we can call it.
+        trim_inputs('/in/focalplane', '/out/focalplane')
+
+    @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
+    def test_trim_targets(self):
+        """Test trim_targets().
+        """
+        with patch('shutil.copytree') as copytree:
+            trim_targets('/in/targets', '/out/targets')
+            copytree.assert_called_with('/in/targets', '/out/targets')
+
+    @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
+    def test_trim_targets(self):
+        """Test trim_targets().
+        """
+        with patch('os.makedirs'):
+            with patch('shutil.copy') as copy:
+                trim_sky('/in/sky', '/out/sky')
+                copy.assert_called_with('/in/sky/solarspec.txt',
+                                        '/out/sky/solarspec.txt')
+
 
 def test_suite():
     """Allows testing of only this module with the command::
+
         python setup.py test -m <modulename>
     """
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_weather.py
+++ b/py/desimodel/test/test_weather.py
@@ -55,19 +55,21 @@ class TestWeather(unittest.TestCase):
         self.assertTrue(np.allclose(norm, 1))
 
     def test_sample_timeseries(self):
-        """Test sampling white noise with uniform 1D PDF
+        """Test sampling white noise with uniform 1D PDF.
         """
         x = np.linspace(-1, 1, 500)
         pdf = np.ones_like(x)
         psd = lambda freq: np.ones_like(freq)
         n, nb = 1000000, 10
-        xs = sample_timeseries(x, pdf, psd, n, gen=self.gen)
+        gen = np.random.RandomState(1)
+        xs = sample_timeseries(x, pdf, psd, n, gen=gen)
         bins, _ = np.histogram(xs, range=(-1,1), bins=nb)
         pred = n / float(nb)
         self.assertTrue(np.allclose(bins, pred, atol=5*np.sqrt(pred)))
 
     def test_same_seed(self):
-        """Same seed should give same samples"""
+        """Same seed should give same samplesself.
+        """
         x_grid = np.linspace(-1, 1, 500)
         pdf_grid = np.ones_like(x_grid)
         psd = lambda freq: np.ones_like(freq)
@@ -79,7 +81,8 @@ class TestWeather(unittest.TestCase):
         self.assertTrue(np.all(x1 == x2))
 
     def test_different_seed(self):
-        """Different seeds should give different samples"""
+        """Different seeds should give different samples.
+        """
         x_grid = np.linspace(-1, 1, 500)
         pdf_grid = np.ones_like(x_grid)
         psd = lambda freq: np.ones_like(freq)
@@ -91,7 +94,7 @@ class TestWeather(unittest.TestCase):
         self.assertTrue(not np.any(x1 == x2))
 
     def test_seeing_median(self):
-        """Check that seeing has expected median
+        """Check that seeing has expected median.
         """
         n = 100000
         for m in (0.9, 1.0, 1.1, 1.2):
@@ -99,7 +102,7 @@ class TestWeather(unittest.TestCase):
             self.assertTrue(np.fabs(np.median(x) - m) < 0.01)
 
     def test_transp_range(self):
-        """Check that transparency has expected range
+        """Check that transparency has expected range.
         """
         n = 100000
         x = sample_transp(n)

--- a/py/desimodel/test/test_weather.py
+++ b/py/desimodel/test/test_weather.py
@@ -12,47 +12,47 @@ from desimodel.weather import *
 class TestWeather(unittest.TestCase):
     """Test desimodel.weather.
     """
+    def setUp(self):
+        self.gen = np.random.RandomState(seed=123)
+
     def test_whiten_identity(self):
         """Check that whitener for samples from a Gaussian is linear.
         """
         mu, sigma = 1.2, 3.4
-        gen = np.random.RandomState(seed=123)
-        x = mu + sigma * gen.normal(size=100000)
-        assert np.allclose(mu, np.mean(x), atol=1e-2)
-        assert np.allclose(sigma, np.std(x), atol=1e-2)
+        x = mu + sigma * self.gen.normal(size=100000)
+        self.assertTrue(np.allclose(mu, np.mean(x), atol=1e-2))
+        self.assertTrue(np.allclose(sigma, np.std(x), atol=1e-2))
         F, G = whiten_transforms(x, data_min=-1e6, data_max=+1e6)
         y = F(x)
-        assert np.allclose(0, np.mean(y), atol=1e-2)
-        assert np.allclose(1, np.std(y), atol=1e-2)
+        self.assertTrue(np.allclose(0, np.mean(y), atol=1e-2))
+        self.assertTrue(np.allclose(1, np.std(y), atol=1e-2))
         ypred = (x - mu) / sigma
-        assert np.allclose(ypred, y, atol=0.2)
+        self.assertTrue(np.allclose(ypred, y, atol=0.2))
 
     def test_whiten_unwhiten_roundtrip(self):
         """Check that F(G(x)) = x for a uniform distribution.
         """
-        gen = np.random.RandomState(seed=123)
         lo, hi = -1.2, +3.4
-        x = gen.uniform(size=10000)
+        x = self.gen.uniform(size=10000)
         F, G = whiten_transforms(x, data_min=lo, data_max=hi)
-        assert np.allclose(G(F(x)), x)
+        self.assertTrue(np.allclose(G(F(x)), x))
 
     def test_whiten_monotonic(self):
         """Check G(x) is monotonically increasing for a uniform distribution.
         """
-        gen = np.random.RandomState(seed=123)
         lo, hi = -1.2, +3.4
-        x = gen.uniform(size=10000)
+        x = self.gen.uniform(size=10000)
         F, G = whiten_transforms(x, data_min=lo, data_max=hi)
         xs = np.sort(x)
         ys = F(xs)
-        assert np.all(np.diff(ys) >= 0)
+        self.assertTrue(np.all(np.diff(ys) >= 0))
 
     def test_seeing_pdf_norm(self):
         """Check that seeing PDF is normalized.
         """
         fwhm, pdf = get_seeing_pdf()
         norm = np.sum(pdf * np.gradient(fwhm))
-        assert np.allclose(norm, 1)
+        self.assertTrue(np.allclose(norm, 1))
 
     def test_sample_timeseries(self):
         """Test sampling white noise with uniform 1D PDF
@@ -61,11 +61,10 @@ class TestWeather(unittest.TestCase):
         pdf = np.ones_like(x)
         psd = lambda freq: np.ones_like(freq)
         n, nb = 1000000, 10
-        gen = np.random.RandomState(1)
-        xs = sample_timeseries(x, pdf, psd, n, gen=gen)
+        xs = sample_timeseries(x, pdf, psd, n, gen=self.gen)
         bins, _ = np.histogram(xs, range=(-1,1), bins=nb)
         pred = n / float(nb)
-        assert np.allclose(bins, pred, atol=5*np.sqrt(pred))
+        self.assertTrue(np.allclose(bins, pred, atol=5*np.sqrt(pred)))
 
     def test_same_seed(self):
         """Same seed should give same samples"""
@@ -95,23 +94,22 @@ class TestWeather(unittest.TestCase):
         """Check that seeing has expected median
         """
         n = 100000
-        gen = np.random.RandomState(seed=123)
         for m in (0.9, 1.0, 1.1, 1.2):
             x = sample_seeing(n, median_seeing=m)
-            assert np.fabs(np.median(x) - m) < 0.01
+            self.assertTrue(np.fabs(np.median(x) - m) < 0.01)
 
     def test_transp_range(self):
         """Check that transparency has expected range
         """
         n = 100000
-        gen = np.random.RandomState(seed=123)
         x = sample_transp(n)
-        assert np.min(x) >= 0 and np.min(x) < 0.0001
-        assert np.max(x) <= 1 and np.max(x) > 0.9999
+        self.assertTrue(np.min(x) >= 0 and np.min(x) < 0.0001)
+        self.assertTrue(np.max(x) <= 1 and np.max(x) > 0.9999)
 
 
 def test_suite():
     """Allows testing of only this module with the command::
+
         python setup.py test -m <modulename>
     """
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/trim.py
+++ b/py/desimodel/trim.py
@@ -6,12 +6,11 @@ desimodel.trim
 
 Code for trimming desimodel/data into smaller files.
 """
-from astropy.io.fits import HDUList, PrimaryHDU, ImageHDU, BinTableHDU
+import os
+import shutil
+import numpy as np
 from astropy.table import Table
 from astropy.io import fits
-import numpy as np
-import os.path
-import shutil
 
 from .footprint import pixweight
 
@@ -150,10 +149,10 @@ def trim_throughput(indir, outdir):
 
     for filename in ('thru-b.fits', 'thru-r.fits', 'thru-z.fits'):
         with fits.open(os.path.join(indir, filename)) as fx:
-            hdus = HDUList()
+            hdus = fits.HDUList()
             hdus.append(fx[0])
-            hdus.append(BinTableHDU(fx[1].data[::20], header=fx[1].header))
-            hdus.append(BinTableHDU(fx[2].data[::20], header=fx[2].header))
+            hdus.append(fits.BinTableHDU(fx[1].data[::20], header=fx[1].header))
+            hdus.append(fits.BinTableHDU(fx[2].data[::20], header=fx[2].header))
             hdus.writeto(os.path.join(outdir, filename))
 
     # galsim-fiber-acceptance.fits is about 230 KB, and it's a fairly
@@ -186,7 +185,7 @@ def trim_psf(indir, outdir, filename):
     outfile = os.path.join(outdir, filename)
 
     fx = fits.open(infile)
-    hdus = HDUList()
+    hdus = fits.HDUList()
 
     #- HDU 0 XCOEFF - data unchanged but update keywords for less samples
     xcoeff = fx[0].data
@@ -198,7 +197,7 @@ def trim_psf(indir, outdir, filename):
     hdr['CDELT2'] = 0.005   #- 5mm instead of 1mm
     hdr['PIXSIZE'] = 0.005   #- 5mm instead of 1mm
 
-    hdus.append(PrimaryHDU(xcoeff, header=hdr))
+    hdus.append(fits.PrimaryHDU(xcoeff, header=hdr))
     hdus.append(fx['YCOEFF'])
 
     #- subsample spots
@@ -213,22 +212,22 @@ def trim_psf(indir, outdir, filename):
     spots[0,2] = rebin_image(inspots[0,10], 5)
     spots[1,2] = rebin_image(inspots[5,10], 5)
     spots[2,2] = rebin_image(inspots[10,10], 5)
-    hdus.append(ImageHDU(spots, header=fx['SPOTS'].header))
+    hdus.append(fits.ImageHDU(spots, header=fx['SPOTS'].header))
 
     #- subsample spots x,y locations
     dx = fx['SPOTX'].data
-    hdus.append(ImageHDU(dx[::5, ::5], header=fx['SPOTX'].header))
+    hdus.append(fits.ImageHDU(dx[::5, ::5], header=fx['SPOTX'].header))
     dy = fx['SPOTY'].data
-    hdus.append(ImageHDU(dy[::5, ::5], header=fx['SPOTY'].header))
+    hdus.append(fits.ImageHDU(dy[::5, ::5], header=fx['SPOTY'].header))
 
     #- Fiberpos unchanged
     hdus.append(fx['FIBERPOS'])
 
     #- Subsample SPOTPOS and SPOTWAVE
     d = fx['SPOTPOS'].data
-    hdus.append(ImageHDU(d[::5], header=fx['SPOTPOS'].header))
+    hdus.append(fits.ImageHDU(d[::5], header=fx['SPOTPOS'].header))
     d = fx['SPOTWAVE'].data
-    hdus.append(ImageHDU(d[::5], header=fx['SPOTWAVE'].header))
+    hdus.append(fits.ImageHDU(d[::5], header=fx['SPOTWAVE'].header))
 
     hdus.writeto(outfile, overwrite=True)
     fx.close()
@@ -239,10 +238,10 @@ def trim_quickpsf(indir, outdir, filename):
     infile = os.path.join(indir, filename)
     outfile = os.path.join(outdir, filename)
     fx = fits.open(infile)
-    hdus = HDUList()
+    hdus = fits.HDUList()
     hdus.append(fx[0])
     for i in [1,2,3]:
         d = fx[i].data
-        hdus.append(BinTableHDU(d[::10], header=fx[i].header))
+        hdus.append(fits.BinTableHDU(d[::10], header=fx[i].header))
     hdus.writeto(outfile, overwrite=True)
     fx.close()

--- a/py/desimodel/weather.py
+++ b/py/desimodel/weather.py
@@ -63,9 +63,9 @@ def whiten_transforms_from_cdf(x, cdf):
     if len(x.shape) != 1:
         raise ValueError('Input arrays must be 1D.')
     if not np.all(np.diff(x) >= 0):
-        raise ValueError('Values of x must be increasing.')
+        raise ValueError('Values of x must be non-decreasing.')
     if not np.all(np.diff(cdf) >= 0):
-        raise ValueError('Values of cdf must be increasing.')
+        raise ValueError('Values of cdf must be non-decreasing.')
     # Normalize.
     cdf /= cdf[-1]
     # Use linear interpolation for the forward and inverse transforms between


### PR DESCRIPTION
This PR:

* Closes #81 by adding some documentation to `doc/update_inputs.rst`.
* Closes #5 by bringing the test coverage of `desimodel.trim` up to 100%.
* Coverage on several other modules was also increased.