### PR TITLE
allow an environment variable in tilesfile

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,9 +7,11 @@ desimodel Release Notes
 
 * Increase test coverage, especially for :mod:`desimodel.trim` (PR `#82`_).
 * Reorganize desimodel.focalplane and add more GFA selection code (PR `#85`_).
+* Allow an environment variable in the tilesfile filename (PR `#87`_).
 
 .. _`#82`: https://github.com/desihub/desimodel/pull/82
 .. _`#85`: https://github.com/desihub/desimodel/pull/85
+.. _`#87`: https://github.com/desihub/desimodel/pull/87
 
 0.9.4 (2018-03-29)
 ------------------

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -172,7 +172,6 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True):
         tilesfile = os.path.join(os.environ['DESIMODEL'],'data','footprint',filename)
 
     #- standarize path location
-    print(tilesfile.format(**os.environ))
     tilesfile = os.path.abspath(tilesfile.format(**os.environ))
 
     if cache and tilesfile in _tiles:

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -172,7 +172,8 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True):
         tilesfile = os.path.join(os.environ['DESIMODEL'],'data','footprint',filename)
 
     #- standarize path location
-    tilesfile = os.path.abspath(tilesfile)
+    print(tilesfile.format(**os.environ))
+    tilesfile = os.path.abspath(tilesfile.format(**os.environ))
 
     if cache and tilesfile in _tiles:
         tiledata = _tiles[tilesfile]


### PR DESCRIPTION
It is convenient to be able to include an environment variable in the `tilesfile` read by `desimodel.io.load_tiles`, for example:
```python
from desimodel.io import load_tiles
load_tiles(tilesfile='{DESIMODEL}/data/footprint/desi-tiles.fits')
```
vs
```python
load_tiles()
```
or, more generally,
```python
load_tiles(tilesfile='{MYENV}/path/to/tiles/mytiles.fits')
```


In detail, this change is handy when using a non-standard tiles file (i.e., a tiles file in a non-standard location) via the configuration file in `desisurvey`.
