### PR TITLE
fix GFA selection bug when no targets overlap

### DIFF
--- a/py/desimodel/focalplane/gfa.py
+++ b/py/desimodel/focalplane/gfa.py
@@ -262,4 +262,11 @@ def get_gfa_targets(targets, rfluxlim=1000, tiles=None, scale=1.0):
                 tiletargets['TILEID'] = tileid
                 target_tables.append(tiletargets)
 
-    return astropy.table.vstack(target_tables)
+    if len(target_tables)>1:
+        result = astropy.table.vstack(target_tables)
+    else:
+        #- Create blank table with correct dtype
+        result = astropy.table.Table(dtype=targets.dtype)
+        result.add_column(astropy.table.Column(name='TILEID', dtype='i4'))
+
+    return result


### PR DESCRIPTION
This PR fixes a bug in `desimodel.focalplane.get_gfa_targets` found by the GFA_targets tutorial: if no input targets cover the GFA, it would crash.  Now it returns an empty table of the correct dtype instead, so that it can still be vstacked with other tables that did have overlaps (e.g. from neighboring input sweep files).