### PR TITLE
Fix tiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,22 +37,22 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.9
         # - SCIPY_VERSION=0.14
-        - ASTROPY_VERSION=2.0.4
+        - ASTROPY_VERSION=2.0.8
         # - SPHINX_VERSION=1.6.6
-        - DESIUTIL_VERSION=1.9.9
-        - SPECTER_VERSION=0.8.3
+        - DESIUTIL_VERSION=1.9.13
+        - SPECTER_VERSION=0.9.0
         # This is the version of the svn data product to export.
-        # - DESIMODEL_VERSION=branches/test-0.9.8
-        - DESIMODEL_VERSION=branches/newtiles
+        - DESIMODEL_VERSION=branches/test-0.9.9
+        # - DESIMODEL_VERSION=trunk
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy healpy numba fitsio'
+        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy healpy numba'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - PIP_ALL_DEPENDENCIES=''
+        - PIP_ALL_DEPENDENCIES='coveralls fitsio'
         # These pip packages need to be installed in a certain order, so we
         # do that separately from the astropy/ci-helpers scripts.
         - DESIHUB_PIP_DEPENDENCIES="desiutil=${DESIUTIL_VERSION} specter=${SPECTER_VERSION}"
@@ -61,7 +61,7 @@ env:
     matrix:
         - SETUP_CMD='egg_info'
         - SETUP_CMD='bdist_egg'
-        - SETUP_CMD='test' CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+        - SETUP_CMD='test' CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES} PIP_DEPENDENCIES=${PIP_ALL_DEPENDENCIES}
 
 matrix:
     # Don't wait for allowed failures.
@@ -75,7 +75,7 @@ matrix:
           env: ASTROPY_VERSION=3.0
                SETUP_CMD='test'
                CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
-
+               PIP_DEPENDENCIES=${PIP_ALL_DEPENDENCIES}
     include:
 
         # Check for sphinx doc build warnings.
@@ -84,7 +84,6 @@ matrix:
         - os: linux
           python: 3.5
           env: SETUP_CMD='build_sphinx --warning-is-error'
-               CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
 
         # Coverage test.  Note that installing the coverage software can
         # change the set of packages installed by conda, so we do
@@ -93,12 +92,14 @@ matrix:
           python: 3.5
           env: SETUP_CMD='test --coverage'
                CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+               PIP_DEPENDENCIES=${PIP_ALL_DEPENDENCIES}
 
         - os: linux
           python: 3.6
           env: ASTROPY_VERSION=3.0
                SETUP_CMD='test'
                CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
+               PIP_DEPENDENCIES=${PIP_ALL_DEPENDENCIES}
 
         # - os: osx
         #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ env:
         - DESIUTIL_VERSION=1.9.13
         - SPECTER_VERSION=0.9.0
         # This is the version of the svn data product to export.
-        - DESIMODEL_VERSION=branches/test-0.9.9
+        # - DESIMODEL_VERSION=branches/test-0.9.9
+        - DESIMODEL_VERSION=branches/newtiles
         # - DESIMODEL_VERSION=trunk
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
         - SPECTER_VERSION=0.8.3
         # This is the version of the svn data product to export.
         # - DESIMODEL_VERSION=branches/test-0.9.8
-        - DESIMODEL_VERSION=trunk
+        - DESIMODEL_VERSION=branches/newtiles
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ env:
         - DESIUTIL_VERSION=1.9.9
         - SPECTER_VERSION=0.8.3
         # This is the version of the svn data product to export.
-        - DESIMODEL_VERSION=branches/test-0.9.8
-        # - DESIMODEL_VERSION=trunk
+        # - DESIMODEL_VERSION=branches/test-0.9.8
+        - DESIMODEL_VERSION=trunk
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -262,6 +262,14 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, outfile=None, outp
     '''
     t0 = time()
 
+    # ADM if tiles or radius is None, load the DESI model defaults.
+    from .focalplane import get_tile_radius_deg
+    if tiles is None:
+        tiles = load_tiles()
+
+    if radius is None:
+        radius = get_tile_radius_deg()
+
     #ADM create an array that is zero for each integer pixel at this nside
     import healpy as hp
     npix = hp.nside2npix(nside)
@@ -352,7 +360,7 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, outfile=None, outp
 
     #ADM find which random points in the fractional pixels are in the DESI footprint
     log.info('Start integration over fractional pixels at edges of DESI footprint...')
-    indesi = is_point_in_desi(load_tiles(),rainmask,decinmask)
+    indesi = is_point_in_desi(tiles,rainmask,decinmask)
     log.info('...{} of the random points in fractional pixels are in DESI...t={:.1f}s'
              .format(np.sum(indesi),time()-t0))
 

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -286,10 +286,10 @@ class TestFootprint(unittest.TestCase):
         hirespixels = partpix64*16+np.arange(16)
         hiresweight = np.mean(pixweight256[hirespixels])
         loresweight = pixweight64[partpix64]
-        #ADM really they should agree to much better than 12%. As "precision" is not set to be
+        #ADM really they should agree to much better than 11%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
         #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
-        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.12))
+        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.11))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -29,25 +29,25 @@ class TestFootprint(unittest.TestCase):
     def test_pass2program(self):
         '''Test footprint.pass2program().
         '''
-        self.assertEqual(footprint.pass2program(0), 'DARK')
+        self.assertEqual(footprint.pass2program(0), 'GRAY')
         self.assertEqual(footprint.pass2program(1), 'DARK')
         self.assertEqual(footprint.pass2program(2), 'DARK')
         self.assertEqual(footprint.pass2program(3), 'DARK')
-        self.assertEqual(footprint.pass2program(4), 'GRAY')
+        self.assertEqual(footprint.pass2program(4), 'DARK')
         self.assertEqual(footprint.pass2program(5), 'BRIGHT')
         self.assertEqual(footprint.pass2program(6), 'BRIGHT')
         self.assertEqual(footprint.pass2program(7), 'BRIGHT')
 
         passes = [0,1,2,3,4,5,6,7]
-        programs = ['DARK', 'DARK', 'DARK', 'DARK', 'GRAY', 'BRIGHT', 'BRIGHT', 'BRIGHT']
+        programs = ['GRAY', 'DARK', 'DARK', 'DARK', 'DARK', 'BRIGHT', 'BRIGHT', 'BRIGHT']
         tmp = footprint.pass2program(passes)
         self.assertEqual(tmp, programs)
 
         tmp = footprint.pass2program(np.array(passes))
         self.assertEqual(tmp, programs)
 
-        tmp = footprint.pass2program([0,0,1])
-        self.assertEqual(tmp, ['DARK', 'DARK', 'DARK'])
+        tmp = footprint.pass2program([0,0,1,2])
+        self.assertEqual(tmp, ['GRAY', 'GRAY', 'DARK', 'DARK'])
 
         with self.assertRaises(KeyError):
             footprint.pass2program(999)
@@ -55,12 +55,12 @@ class TestFootprint(unittest.TestCase):
     def test_program2pass(self):
         '''Test footprint.program2pass().
         '''
-        self.assertEqual(footprint.program2pass('DARK'), [0,1,2,3])
-        self.assertEqual(footprint.program2pass('GRAY'), [4,])
+        self.assertEqual(footprint.program2pass('DARK'), [1,2,3,4])
+        self.assertEqual(footprint.program2pass('GRAY'), [0,])
         self.assertEqual(footprint.program2pass('BRIGHT'), [5,6,7])
-        self.assertEqual(footprint.program2pass(['DARK', 'GRAY']), [[0,1,2,3], [4,]])
+        self.assertEqual(footprint.program2pass(['DARK', 'GRAY']), [[1,2,3,4], [0,]])
         self.assertEqual(footprint.program2pass(np.array(['DARK', 'GRAY'])),
-                                                [[0,1,2,3], [4,]])
+                                                [[1,2,3,4], [0,]])
         with self.assertRaises(ValueError):
             footprint.program2pass('BLAT')
 
@@ -286,10 +286,10 @@ class TestFootprint(unittest.TestCase):
         hirespixels = partpix64*16+np.arange(16)
         hiresweight = np.mean(pixweight256[hirespixels])
         loresweight = pixweight64[partpix64]
-        #ADM really they should agree to much better than 11%. As "precision" is not set to be
+        #ADM really they should agree to much better than 12%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
         #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
-        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.11))
+        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.12))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -245,8 +245,12 @@ class TestFootprint(unittest.TestCase):
                                       ('PROGRAM', (str, 6)),
                                   ])
 
-        #ADM I found a full (180) partial (406) and empty (1000) HEALPixel at nside=256
-        fullpix256 = np.array([180])
+        #ADM I found a full (170) partial (406) and empty (1000) HEALPixel at nside=256
+        #ADM that are also full, partial, empty at nside=64.
+        #ADM You can find these with, e.g.:
+        #ADM pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.01)
+        #ADM np.where(pixweight256 == 1)
+        fullpix256 = np.array([170])
         partpix256 = np.array([406])
         emptypix256 = np.array([1000])
         #ADM In the nested scheme you can traverse from 256 to 64 by integer division
@@ -271,8 +275,8 @@ class TestFootprint(unittest.TestCase):
         radius = 1.605
 
         #ADM determine the weight array for pixels at nsides of 64 and 256
-        pixweight64 = footprint.pixweight(64,tiles=tiles,radius=radius,precision=0.04)
-        pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.04)
+        pixweight64 = footprint.pixweight(64,tiles=tiles,radius=radius,precision=0.01)
+        pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.01)
 
         #ADM check that the full pixel is assigned a weight of 1 at each nside
         self.assertTrue(np.all(pixweight64[fullpix64]==1))
@@ -286,10 +290,11 @@ class TestFootprint(unittest.TestCase):
         hirespixels = partpix64*16+np.arange(16)
         hiresweight = np.mean(pixweight256[hirespixels])
         loresweight = pixweight64[partpix64]
-        #ADM really they should agree to much better than 11%. As "precision" is not set to be
+        #ADM really they should agree to much better than 2%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
-        #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
-        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.11))
+        #ADM I checked that at precision = 0.01 this doesn't fail after 1000 attempts
+        #ADM (the largest difference I encountered was 0.015)
+        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.02))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -228,15 +228,20 @@ class TestIO(unittest.TestCase):
         tf = io.load_tiles(onlydesi=False, extra=True)
         tt = Table.read(fitstiles)
         te = Table.read(ecsvtiles, format='ascii.ecsv')
+
         self.assertEqual(sorted(tf.dtype.names), sorted(tt.colnames))
-        self.assertEqual(sorted(tf.dtype.names), sorted(te.colnames))
+
+        #- ECSV is a subset of the columns
+        missing = set(te.colnames) - set(tf.dtype.names)
+        self.assertEqual(len(missing), 0)
 
         for col in tt.colnames:
             self.assertTrue(np.all(tf[col]==tt[col]), 'fits[{col}] != table[{col}]'.format(col=col))
-            if np.issubdtype(tf[col].dtype, np.floating):
-                self.assertTrue(np.allclose(tf[col], te[col], atol=1e-4, rtol=1e-4), 'fits[{col}] != ecsv[{col}]'.format(col=col))
-            else:
-                self.assertTrue(np.all(tf[col]==te[col]), 'fits[{col}] != ecsv[{col}]'.format(col=col))
+            if col in te.colnames:
+                if np.issubdtype(tf[col].dtype, np.floating):
+                    self.assertTrue(np.allclose(tf[col], te[col], atol=1e-4, rtol=1e-4), 'fits[{col}] != ecsv[{col}]'.format(col=col))
+                else:
+                    self.assertTrue(np.all(tf[col]==te[col]), 'fits[{col}] != ecsv[{col}]'.format(col=col))
 
         for program in set(tf['PROGRAM']):
             self.assertTrue((program[-1] != ' ') and (program[-1] != b' '))

--- a/py/desimodel/trim.py
+++ b/py/desimodel/trim.py
@@ -72,6 +72,12 @@ def trim_footprint(indir, outdir):
     ii = (35 < t['RA']) & (t['RA'] < 55) & (-10 < t['DEC']) & (t['DEC'] < 20)
     tx = t[ii]
     tx.write(outfile, format='fits')
+
+    #- Remove multidimensional columns before writing ecsv
+    for colname in ['BRIGHTRA', 'BRIGHTDEC', 'BRIGHTVTMAG']:
+        if colname in tx.colnames:
+            tx.remove_column(colname)
+
     tx.write(outfile.replace('.fits', '.ecsv'), format='ascii.ecsv')
     infile, outfile = inout(indir, outdir, 'desi-healpix-weights.fits')
     # Use a low precision to speed up the calculation.  Use lower nside


### PR DESCRIPTION
We have a new desi-tiles.fits file with a better dithering, but it broke code and tests for several reasons:
* new multi-dimensional columns that can't be exported to ecsv
* GRAY layer is not 0, not 4

This PR mostly fixes the code and tests to work with this new tile file, but I'm still having trouble with `desimodel.test.test_footprint.test_partial_pixels`, which sometimes passes and sometimes fails.  The original test was already quite loose in testing the consistency between high and low resolution pixel weighting.  @geordie666 could you take a look and help with that?