### PR TITLE
change interpretation of tile radius from typical to maximum

### DIFF
--- a/py/desimodel/focalplane/geometry.py
+++ b/py/desimodel/focalplane/geometry.py
@@ -21,18 +21,18 @@ _tile_radius_deg = None
 _tile_radius_mm = None
 
 def get_tile_radius_mm():
-    '''Returns radius in mm to the middle of the outermost positioner.
+    '''Returns maximum radius in mm covered by the outermost positioner.
     '''
     global _tile_radius_mm
     if _tile_radius_mm is None:
         fp = load_fiberpos()
         p = load_desiparams()
-        _tile_radius_mm = np.sqrt(np.max(fp['X']**2 + fp['Y']**2))  # + p['positioners']['radius_max']
+        _tile_radius_mm = np.sqrt(np.max(fp['X']**2 + fp['Y']**2)) + p['positioners']['radius_max']
     return _tile_radius_mm
 
 
 def get_tile_radius_deg():
-    '''Returns radius in degrees to the middle of the outermost positioner.
+    '''Returns maximum radius in degrees covered by the outermost positioner.
     '''
     global _tile_radius_deg
     if _tile_radius_deg is None:


### PR DESCRIPTION
This PR addresses issue #99 by changing the interpretation of `desimodel.focalplane.get_tile_radius_mm()` and `.get_tile_radius_deg()` to be the radius of the maximum reach of the outermost positioner, instead of the middle of the outermost positioner (which also corresponded to the typical maximum reach of the outer ring of positioners).

i.e. tile_radius_mm 407.484 mm (old) -> 413.484 mm (new) and tile_radius_deg 1.6058 degrees (old) -> 1.6275 degrees (new).

This has the consequence that `desimodel.footprint.is_point_in_desi()` will return more false positives, but it will no longer exclude targets that actually could have been reached.