### PR TITLE
Time-varying focalplane state

### DIFF
--- a/bin/desi_generate_focalplane
+++ b/bin/desi_generate_focalplane
@@ -27,7 +27,7 @@ def main():
 
     parser.add_argument("--exclusion", type=str, default="legacy",
                         required=False,
-                        help="The name of the default exclusion polynomials"
+                        help="The name of the default exclusion polygon"
                         " to use (e.g. 'legacy', 'default', etc)")
 
     parser.add_argument("--petal_id2loc", type=str, required=False,
@@ -35,6 +35,11 @@ def main():
                         "specified as '<id0>:<loc0>,<id1>:<loc1>,...'.  If"
                         " not specified, petals will be placed in ID order"
                         " starting at location 0.")
+
+    parser.add_argument("--startvalid", type=str, required=False, default=None,
+                        help="Optional start date (default is current "
+                        "date/time) when the focalplane becomes valid. "
+                        "Format is YYYY-MM-DDTHH:mm:ss in UTC time.")
 
     parser.add_argument("--fillfake", required=False, default=False,
                         action="store_true",
@@ -51,6 +56,11 @@ def main():
                         " with legacy fiberassignment and should not be used"
                         " for anything else.")
 
+    parser.add_argument("--fakefiberpos", required=False, default=False,
+                        action="store_true",
+                        help="Use the old fiberpos file for the device "
+                        "mapping.  Only for testing.")
+
     args = parser.parse_args()
 
     petalloc = None
@@ -62,8 +72,9 @@ def main():
 
     create(testdir=args.test, posdir=args.pos_settings,
            polyfile=args.collision, fibermaps=None, petalloc=petalloc,
-           startvalid=None, fillfake=args.fillfake, exclusion=args.exclusion,
-           fakeoffset=args.fakeoffset)
+           startvalid=args.startvalid, fillfake=args.fillfake,
+           exclusion=args.exclusion, fakeoffset=args.fakeoffset,
+           fakefiberpos=args.fakefiberpos)
 
     return
 

--- a/bin/desi_generate_focalplane
+++ b/bin/desi_generate_focalplane
@@ -44,6 +44,13 @@ def main():
     parser.add_argument("--test", type=str, required=False, default=None,
                         help="Override the output directory for testing.")
 
+    parser.add_argument("--fakeoffset", required=False, default=False,
+                        action="store_true",
+                        help="Set theta / phi offsets to zero for fake"
+                        " positioners.  This is *only* for consistency tests"
+                        " with legacy fiberassignment and should not be used"
+                        " for anything else.")
+
     args = parser.parse_args()
 
     petalloc = None
@@ -55,7 +62,8 @@ def main():
 
     create(testdir=args.test, posdir=args.pos_settings,
            polyfile=args.collision, fibermaps=None, petalloc=petalloc,
-           startvalid=None, fillfake=args.fillfake, exclusion=args.exclusion)
+           startvalid=None, fillfake=args.fillfake, exclusion=args.exclusion,
+           fakeoffset=args.fakeoffset)
 
     return
 

--- a/bin/desi_update_focalplane_log
+++ b/bin/desi_update_focalplane_log
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""Commandline script to update the state log for a focalplane.
+"""
+import os
+import shutil
+import argparse
+
+from datetime import datetime
+
+from astropy.table import Table
+
+from desimodel.io import load_focalplane, datadir
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--location", type=int, required=False, default=None,
+                        help="The device location (petal * 1000 + device loc)"
+                        " modified by this event.")
+
+    parser.add_argument("--petal", type=int, required=False, default=None,
+                        help="The petal (focalplane location, not petal ID)"
+                        " modified by this event (--device must also be used)")
+
+    parser.add_argument("--device", type=int, required=False, default=None,
+                        help="The device location (--petal must also be given)"
+                        " modified by this event.")
+
+    parser.add_argument("--state", type=int, default=None, required=False,
+                        help="The new state to assign to the device.")
+
+    parser.add_argument("--exclusion", type=str, default=None, required=False,
+                        help="The new exclusion polygon to assign to the"
+                        " device (e.g. 'legacy', 'default', etc)")
+
+    parser.add_argument("--time", type=str, required=False, default=None,
+                        help="Optional date/time (default is current "
+                        "date/time) when this event happens. "
+                        "Format is YYYY-MM-DDTHH:mm:ss in UTC time.")
+
+    args = parser.parse_args()
+
+    if args.location is None:
+        if (args.petal is None) or (args.device is None):
+            raise RuntimeError(
+                "must specify either location or petal and device")
+    else:
+        if (args.petal is not None) or (args.device is not None):
+            raise RuntimeError(
+                "must specify either location or petal and device, not both")
+
+    # The timestamp for this event.
+
+    event = None
+    if args.time is None:
+        event = datetime.utcnow()
+    else:
+        event = datetime.strptime(args.time, "%Y-%m-%dT%H:%M:%S")
+    timestr = event.isoformat(timespec="seconds")
+
+    # First, load the current state
+
+    fp, exclude, state, tmstr = load_focalplane(event)
+
+    # Find the properties of the specified device.
+
+    new_pet = args.petal
+    new_dev = args.device
+    new_loc = args.location
+    new_st = args.state
+    new_excl = args.exclusion
+    if args.location is not None:
+        for row in state:
+            if row["LOCATION"] == args.location:
+                new_pet = row["PETAL"]
+                new_dev = row["DEVICE"]
+                if new_st is None:
+                    new_st = row["STATE"]
+                if new_excl is None:
+                    new_excl = row["EXCLUSION"]
+    else:
+        for row in state:
+            if (row["PETAL"] == args.petal) and (row["DEVICE"] == args.device):
+                new_loc = row["LOCATION"]
+                if new_st is None:
+                    new_st = row["STATE"]
+                if new_excl is None:
+                    new_excl = row["EXCLUSION"]
+
+    fpdir = os.path.join(datadir(), "focalplane")
+    state_file = os.path.join(fpdir, "desi-state_{}.ecsv".format(tmstr))
+    tmp_state = "{}.tmp".format(state_file)
+    prev_state = "{}.previous".format(state_file)
+
+    # Now read the full state file and append
+    st = Table.read(state_file, format="ascii.ecsv")
+    st.add_row([timestr, new_pet, new_loc, new_dev, new_st, new_excl])
+    st.write(tmp_state, format='ascii.ecsv')
+
+    # now move the temp file into place
+    shutil.copy2(state_file, prev_state)
+    os.rename(tmp_state, state_file)
+
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/generate_focalplane
+++ b/bin/generate_focalplane
@@ -10,7 +10,8 @@ from desimodel.inputs.focalplane import create
 def main():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("--pos_settings", type=str, required=True,
+    parser.add_argument("--pos_settings", type=str, default=None,
+                        required=False,
                         help="The directory containing the positioner "
                         "settings files.  For example, DESI svn "
                         "fp_settings/pos_settings.  The file names are "
@@ -18,23 +19,22 @@ def main():
                         "devices with an assigned PETAL_ID and DEVICE_LOC "
                         "are considered.")
 
-    parser.add_argument("--collision", type=str, required=True,
+    parser.add_argument("--collision", type=str, default=None,
+                        required=False,
                         help="The text config file containing the exclusion "
                         "polygons to use.  For example, "
                         "'_collision_settings_DEFAULT.conf'")
+
+    parser.add_argument("--exclusion", type=str, default="legacy",
+                        required=False,
+                        help="The name of the default exclusion polynomials"
+                        " to use (e.g. 'legacy', 'default', etc)")
 
     parser.add_argument("--petal_id2loc", type=str, required=False,
                         help="Mapping of petal ID to focalplane location, "
                         "specified as '<id0>:<loc0>,<id1>:<loc1>,...'.  If"
                         " not specified, petals will be placed in ID order"
                         " starting at location 0.")
-
-    parser.add_argument("--petal_loc2spec", type=str, required=False,
-                        help="Mapping of petal location to spectrograph, "
-                        "specified as '<loc0>:<spec0>,<loc1>:<spec1>,...'.  If"
-                        " not specified, petal locations which are populated"
-                        " by petal IDs will be assigned to spectrographs in"
-                        " numerical order.")
 
     parser.add_argument("--fillfake", required=False, default=False,
                         action="store_true",
@@ -53,16 +53,9 @@ def main():
         for k, v in kv.items():
             petalloc[k] = v
 
-    petalspec = None
-    if args.petal_loc2spec is not None:
-        petalspec = dict()
-        kv = args.petal_loc2spec.split(",")
-        for k, v in kv.items():
-            petalspec[k] = v
-
     create(testdir=args.test, posdir=args.pos_settings,
            polyfile=args.collision, fibermaps=None, petalloc=petalloc,
-           petalspec=petalspec, startvalid=None, fillfake=args.fillfake)
+           startvalid=None, fillfake=args.fillfake, exclusion=args.exclusion)
 
     return
 

--- a/bin/generate_focalplane
+++ b/bin/generate_focalplane
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""Commandline script to create a focalplane model.
+"""
+
+import argparse
+
+from desimodel.inputs.focalplane import create
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--pos_settings", type=str, required=True,
+                        help="The directory containing the positioner "
+                        "settings files.  For example, DESI svn "
+                        "fp_settings/pos_settings.  The file names are "
+                        "assumed to have the form unit_<name>.conf.  Only "
+                        "devices with an assigned PETAL_ID and DEVICE_LOC "
+                        "are considered.")
+
+    parser.add_argument("--collision", type=str, required=True,
+                        help="The text config file containing the exclusion "
+                        "polygons to use.  For example, "
+                        "'_collision_settings_DEFAULT.conf'")
+
+    parser.add_argument("--petal_id2loc", type=str, required=False,
+                        help="Mapping of petal ID to focalplane location, "
+                        "specified as '<id0>:<loc0>,<id1>:<loc1>,...'.  If"
+                        " not specified, petals will be placed in ID order"
+                        " starting at location 0.")
+
+    parser.add_argument("--petal_loc2spec", type=str, required=False,
+                        help="Mapping of petal location to spectrograph, "
+                        "specified as '<loc0>:<spec0>,<loc1>:<spec1>,...'.  If"
+                        " not specified, petal locations which are populated"
+                        " by petal IDs will be assigned to spectrographs in"
+                        " numerical order.")
+
+    parser.add_argument("--fillfake", required=False, default=False,
+                        action="store_true",
+                        help="For simulations, fill empty device locations"
+                        " with fake positioners")
+
+    parser.add_argument("--test", type=str, required=False, default=None,
+                        help="Override the output directory for testing.")
+
+    args = parser.parse_args()
+
+    petalloc = None
+    if args.petal_id2loc is not None:
+        petalloc = dict()
+        kv = args.petal_id2loc.split(",")
+        for k, v in kv.items():
+            petalloc[k] = v
+
+    petalspec = None
+    if args.petal_loc2spec is not None:
+        petalspec = dict()
+        kv = args.petal_loc2spec.split(",")
+        for k, v in kv.items():
+            petalspec[k] = v
+
+    create(testdir=args.test, posdir=args.pos_settings,
+           polyfile=args.collision, fibermaps=None, petalloc=petalloc,
+           petalspec=petalspec, startvalid=None, fillfake=args.fillfake)
+
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -236,14 +236,14 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
 
     # First the THETA arm.
     circs = [
-        ((3.0, 0.0), 2.095)
+        [[3.0, 0.0], 2.095]
     ]
     seg = [
-        (5.095, -0.474),
-        (4.358, -2.5),
-        (2.771, -2.5),
-        (1.759, -2.792),
-        (0.905, -0.356)
+        [5.095, -0.474],
+        [4.358, -2.5],
+        [2.771, -2.5],
+        [1.759, -2.792],
+        [0.905, -0.356]
     ]
     segs = [seg]
     shp_theta = dict()
@@ -252,18 +252,18 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
 
     # Now the PHI arm
     circs = [
-        ((0.0, 0.0), 0.967)
+        [[0.0, 0.0], 0.967]
     ]
     seg_upper = [
-        (-3.0, 0.990),
-        (0.0, 0.990)
+        [-3.0, 0.990],
+        [0.0, 0.990]
     ]
     seg_lower = [
-        (-2.944, -1.339),
-        (-2.944, -2.015),
-        (-1.981, -1.757),
-        (-1.844, -0.990),
-        (0.0, -0.990)
+        [-2.944, -1.339],
+        [-2.944, -2.015],
+        [-1.981, -1.757],
+        [-1.844, -0.990],
+        [0.0, -0.990]
     ]
     segs = [seg_upper, seg_lower]
     shp_phi = dict()
@@ -281,16 +281,16 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
         ktheta_raw = np.transpose(np.array(exprops["KEEPOUT_THETA"]))
         ktheta_x = ktheta_raw[:, 0]
         ktheta_y = ktheta_raw[:, 1]
-        ktheta = [(float(x), float(y)) for x, y in zip(ktheta_x, ktheta_y)]
-        kstart = tuple(ktheta[0])
+        ktheta = [[float(x), float(y)] for x, y in zip(ktheta_x, ktheta_y)]
+        kstart = list(ktheta[0])
         ktheta.append(kstart)
         poly["default"]["theta"] = dict()
         poly["default"]["theta"]["segments"] = [ktheta]
         kphi_raw = np.transpose(np.array(exprops["KEEPOUT_PHI"]))
         kphi_x = kphi_raw[:, 0]
         kphi_y = kphi_raw[:, 1]
-        kphi = [(float(x), float(y)) for x, y in zip(kphi_x, kphi_y)]
-        kstart = tuple(kphi[0])
+        kphi = [[float(x), float(y)] for x, y in zip(kphi_x, kphi_y)]
+        kstart = list(kphi[0])
         kphi.append(kstart)
         poly["default"]["phi"] = dict()
         poly["default"]["phi"]["segments"] = [kphi]
@@ -429,8 +429,10 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
                description="Petal location [0-9]"),
         Column(name="DEVICE", length=nrows, dtype=np.int32,
                description="Device location on the petal"),
+        Column(name="LOCATION", length=nrows, dtype=np.int32,
+               description="Global device location (PETAL * 1000 + DEVICE)"),
         Column(name="STATE", length=nrows, dtype=np.uint32,
-               description="Bit field"),
+               description="State bit field (good == 0)"),
     ]
 
     out_state = Table()
@@ -442,6 +444,7 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
         for dev in devlist:
             out_state[row]["TIME"] = file_date
             out_state[row]["PETAL"] = fp[petal][dev]["PETAL"]
+            out_state[row]["LOCATION"] = fp[petal][dev]["PETAL"] * 1000 + dev
             out_state[row]["DEVICE"] = dev
             out_state[row]["STATE"] = 0
             row += 1

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -1,0 +1,457 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+desimodel.inputs.focalplane
+==============================
+
+Utilities for constructing a focalplane model.
+"""
+import os
+from datetime import datetime
+import re
+import csv
+import yaml
+
+import configobj
+import numpy as np
+from astropy.table import Table, Column
+
+from desiutil.log import get_logger
+
+from . import docdb
+
+from ..io import datadir
+
+
+def _compute_theta_phi_range(phys_t, phys_p):
+    """Compute the min/max range about the initial offset.
+
+    Based on the "full_range" defined in plate_control/petal/posmodel.py
+
+    Args:
+        phys_t (float):  PHYSICAL_RANGE_T in degrees.
+        phys_p (float):  PHYSICAL_RANGE_P in degrees.
+
+    Returns:
+        (tuple):  The (theta_min, theta_max, phi_min, phi_max) angles.
+
+    """
+    t_min = -0.5 * phys_t
+    t_max = 0.5 * phys_t
+    p_min = 185.0 - phys_p
+    p_max = 185.0
+    return (t_min, t_max, p_min, p_max)
+
+
+def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
+          petalloc=None, petalspec=None, startvalid=None):
+    """Construct DESI focalplane and state files.
+
+    This function gathers information from the following sources:
+
+
+
+    """
+    log = get_logger()
+
+    outdir = testdir
+    if outdir is None:
+        outdir = os.path.join(datadir(), "focalplane")
+    if posdir is None:
+        msg = "you must specify the local directory of positioner conf files"
+        raise RuntimeError(msg)
+
+    if startvalid is None:
+        startvalid = datetime.utcnow()
+    else:
+        startvalid = datetime.strptime(startvalid, "%Y-%m-%dT%H:%M:%S")
+
+    if fibermaps is None:
+        fibermaps = [
+            (4042, 5, "Petal_2_final_verification.csv"),
+            (4043, 6, "Petal_3_final_verification.csv"),
+            (4807, 2, "Petal_4_final_verification.csv"),
+            (4808, 3, "Petal_5_final_verification.csv"),
+            (4809, 2, "Petal_6_final_verification.csv"),
+            (4190, 6, "Petal_7_final_verification.csv"),
+            (4806, 4, "Petal_8_final_verification.csv"),
+            (4810, 3, "Petal_9_final_verification.csv"),
+            (4868, 3, "Petal_10_final_verification.csv"),
+            (4883, 3, "Petal_11_final_verification.csv")
+        ]
+
+    # Process the fibermap files from DocDB.  We start with this step so that
+    # we can build the list of all physical PETAL_IDs that have a mapping.
+    # Later, we will get positioner data only for devices that exist in the
+    # mapping.
+    allpetals = set()
+    fp = dict()
+
+    for docnum, docver, docname in fibermaps:
+        fmfile = None
+        try:
+            fmfile = docdb.download(docnum, docver, docname)
+        except IOError:
+            msg = "Could not download {}".format(docname)
+            log.error(msg)
+        firstline = True
+        with open(fmfile, newline="") as csvfile:
+            reader = csv.reader(csvfile, delimiter=",")
+            cols = dict()
+            for row in reader:
+                if firstline:
+                    for cnum, elem in enumerate(row):
+                        nm = elem.strip().rstrip()
+                        cols[nm] = cnum
+                    firstline = False
+                else:
+                    pet = int(row[cols["PETAL_ID"]])
+                    allpetals.add(pet)
+                    dev = int(row[cols["DEVICE_LOC"]])
+                    blkfib = row[cols["slit_position"]].split(":")
+                    blk = int(blkfib[0])
+                    fib = int(blkfib[1])
+                    if pet not in fp:
+                        fp[pet] = dict()
+                    if dev not in fp[pet]:
+                        empty = dict()
+                        empty["DEVICE_ID"] = "NONE"
+                        fp[pet][dev] = empty
+                    fp[pet][dev]["SLITBLOCK"] = blk
+                    fp[pet][dev]["BLOCKFIBER"] = fib
+
+    # Parse all the positioner files.
+    pos = dict()
+    pospat = re.compile(r"unit_(.*).conf")
+    for root, dirs, files in os.walk(posdir):
+        for f in files:
+            posmat = pospat.match(f)
+            if posmat is not None:
+                file_dev = posmat.group(1)
+                pfile = os.path.join(root, f)
+                print("parsing {}".format(pfile), flush=True)
+                cnf = configobj.ConfigObj(pfile, unrepr=True)
+                # Is this device used?
+                if ("DEVICE_LOC" not in cnf) \
+                        or (int(cnf["DEVICE_LOC"]) < 0):
+                    continue
+                if ("PETAL_ID" not in cnf):
+                    continue
+                pet = int(cnf["PETAL_ID"])
+                if (pet < 0) or (pet not in fp):
+                    continue
+                # Check that the positioner ID in the file name matches
+                # the file contents.
+                if file_dev != cnf["POS_ID"]:
+                    msg = "positioner file {} has device {} in its name "\
+                        "but contains POS_ID={}"\
+                        .format(f, file_dev, cnf["POS_ID"])
+                    raise RuntimeError(msg)
+                # Add properties to dictionary
+                pos[file_dev] = cnf
+        break
+
+    # Extract and organize the information we are tracking
+
+    for devid, props in pos.items():
+        pet = int(props["PETAL_ID"])
+        dev = int(props["DEVICE_LOC"])
+        if dev not in fp[pet]:
+            # This device location must not be a POS type.  We still want
+            # its information though.
+            fp[pet][dev] = dict()
+            fp[pet][dev]["SLITBLOCK"] = -1
+            fp[pet][dev]["BLOCKFIBER"] = -1
+        fp[pet][dev]["DEVICE_ID"] = devid
+        t_min, t_max, p_min, p_max = _compute_theta_phi_range(
+            props["PHYSICAL_RANGE_T"], props["PHYSICAL_RANGE_P"])
+        fp[pet][dev]["OFFSET_X"] = props["OFFSET_X"]
+        fp[pet][dev]["OFFSET_Y"] = props["OFFSET_Y"]
+        fp[pet][dev]["OFFSET_T"] = props["OFFSET_T"]
+        fp[pet][dev]["OFFSET_P"] = props["OFFSET_P"]
+        fp[pet][dev]["LENGTH_R1"] = props["LENGTH_R1"]
+        fp[pet][dev]["LENGTH_R2"] = props["LENGTH_R2"]
+        fp[pet][dev]["MIN_T"] = t_min
+        fp[pet][dev]["MAX_T"] = t_max
+        fp[pet][dev]["MIN_P"] = p_min
+        fp[pet][dev]["MAX_P"] = p_max
+
+    # This is awkward- we have no source of information about the mapping
+    # from device location on a petal to "device type" (i.e. whether that
+    # location is a normal positioner or something else).  We resort to
+    # fetching docdb 0530 just to get this one column...
+    xls_fp_layout = docdb.download(
+        530, 14, "DESI-0530-v14 (Focal Plane Layout).xlsx")
+    xls_sheet = "PositionerAndFiducialLocations"
+    rowmin, rowmax = 49, 591
+    headers = docdb.xls_read_row(xls_fp_layout, xls_sheet, rowmin-1, "B", "S")
+    assert headers[0] == "device_location_id"
+    assert headers[1] == "device_type"
+    xls_devloc = docdb.xls_read_col(
+        xls_fp_layout, xls_sheet, "B", rowmin, rowmax, dtype=int)
+    xls_devtype = docdb.xls_read_col(
+        xls_fp_layout, xls_sheet, "C", rowmin, rowmax, dtype=str)
+    devtype = dict()
+    for loc, typ in zip(xls_devloc, xls_devtype):
+        devtype[int(loc)] = typ
+
+    for petal in sorted(allpetals):
+        devlist = list(sorted(fp[petal].keys()))
+        for dev in devlist:
+            fp[petal][dev]["DEVICE_TYPE"] = devtype[dev]
+
+    # If we have a map of petal ID to petal location, then use it.  Otherwise
+    # just assign them in petal ID order.
+    if petalloc is None:
+        loc = 0
+        for petal in sorted(allpetals):
+            devlist = list(sorted(fp[petal].keys()))
+            for dev in devlist:
+                fp[petal][dev]["PETAL"] = loc
+            loc += 1
+    else:
+        for petal in allpetals:
+            devlist = list(sorted(fp[petal].keys()))
+            for dev in devlist:
+                fp[petal][dev]["PETAL"] = petalloc[petal]
+
+    # If we have a map of petal ID to spectrograph, then use it.  Otherwise
+    # just assign them in petal ID order.
+    if petalspec is None:
+        spec = 0
+        for petal in sorted(allpetals):
+            devlist = list(sorted(fp[petal].keys()))
+            for dev in devlist:
+                fp[petal][dev]["SPECTROGRAPH"] = spec
+            spec += 1
+    else:
+        for petal in allpetals:
+            devlist = list(sorted(fp[petal].keys()))
+            for dev in devlist:
+                fp[petal][dev]["SPECTROGRAPH"] = petalspec[petal]
+
+    # Now load the file(s) with the exclusion polygons
+    # Add the legacy polygons to the dictionary for reference.
+    poly = dict()
+
+    # First the THETA arm.
+    circs = [
+        ((3.0, 0.0), 2.095)
+    ]
+    seg = [
+        (5.095, -0.474),
+        (4.358, -2.5),
+        (2.771, -2.5),
+        (1.759, -2.792),
+        (0.905, -0.356)
+    ]
+    segs = [seg]
+    shp_theta = dict()
+    shp_theta["circles"] = circs
+    shp_theta["segments"] = segs
+
+    # Now the PHI arm
+    circs = [
+        ((0.0, 0.0), 0.967)
+    ]
+    seg_upper = [
+        (-3.0, 0.990),
+        (0.0, 0.990)
+    ]
+    seg_lower = [
+        (-2.944, -1.339),
+        (-2.944, -2.015),
+        (-1.981, -1.757),
+        (-1.844, -0.990),
+        (0.0, -0.990)
+    ]
+    segs = [seg_upper, seg_lower]
+    shp_phi = dict()
+    shp_phi["circles"] = circs
+    shp_phi["segments"] = segs
+
+    poly["legacy"] = dict()
+    poly["legacy"]["theta"] = shp_theta
+    poly["legacy"]["phi"] = shp_phi
+
+    if polyfile is not None:
+        # Add shapes from other files
+        exprops = configobj.ConfigObj(polyfile, unrepr=True)
+        poly["default"] = dict()
+        ktheta_raw = np.transpose(np.array(exprops["KEEPOUT_THETA"]))
+        ktheta_x = ktheta_raw[:, 0]
+        ktheta_y = ktheta_raw[:, 1]
+        ktheta = [(float(x), float(y)) for x, y in zip(ktheta_x, ktheta_y)]
+        kstart = tuple(ktheta[0])
+        ktheta.append(kstart)
+        poly["default"]["theta"] = dict()
+        poly["default"]["theta"]["segments"] = [ktheta]
+        kphi_raw = np.transpose(np.array(exprops["KEEPOUT_PHI"]))
+        kphi_x = kphi_raw[:, 0]
+        kphi_y = kphi_raw[:, 1]
+        kphi = [(float(x), float(y)) for x, y in zip(kphi_x, kphi_y)]
+        kstart = tuple(kphi[0])
+        kphi.append(kstart)
+        poly["default"]["phi"] = dict()
+        poly["default"]["phi"]["segments"] = [kphi]
+
+    # Here is where we could assign exclusion polygons to each device ID,
+    # based on how a given positioner is moving.  For now we assign them all
+    # to the same set of polygons.
+    for petal in sorted(allpetals):
+        devlist = list(sorted(fp[petal].keys()))
+        for dev in devlist:
+            fp[petal][dev]["EXCLUSION"] = "legacy"
+
+    # Now write out all of this collected information.  Also write out an
+    # initial "state" log as a starting point.  Note that by having log
+    # files (which contain datestamps) also have a "starting" date, it means
+    # that we don't need a single log for the entire survey.
+
+    file_date = startvalid.isoformat(timespec="seconds")
+    out_fp_file = os.path.join(
+        outdir, "desi-focalplane_{}.ecsv".format(file_date))
+    out_poly_file = os.path.join(
+        outdir, "desi-exclusion_{}.yaml".format(file_date))
+    out_state_file = os.path.join(
+        outdir, "desi-state_{}.ecsv".format(file_date))
+
+    # First the focalplane file
+
+    nrows = 0
+    for petal in sorted(allpetals):
+        devlist = list(sorted(fp[petal].keys()))
+        nrows += len(devlist)
+
+    out_cols = [
+        Column(name="PETAL", length=nrows, dtype=np.int32,
+               description="Petal location [0-9]"),
+        Column(name="DEVICE", length=nrows, dtype=np.int32,
+               description="Device location on the petal"),
+        Column(name="LOCATION", length=nrows, dtype=np.int32,
+               description="PETAL * 1000 + DEVICE"),
+        Column(name="PETAL_ID", length=nrows, dtype=np.int32,
+               description="The physical petal ID"),
+        Column(name="DEVICE_ID", length=nrows, dtype=np.dtype("a9"),
+               description="The physical device ID string"),
+        Column(name="DEVICE_TYPE", length=nrows, dtype=np.dtype("a3"),
+               description="The device type (POS, ETC, FIF)"),
+        Column(name="SLITBLOCK", length=nrows, dtype=np.int32,
+               description="The slit block where this fiber goes"),
+        Column(name="BLOCKFIBER", length=nrows, dtype=np.int32,
+               description="The fiber index within the slit block"),
+        Column(name="SPECTROGRAPH", length=nrows, dtype=np.int32,
+               description="The spectrograph connected to this petal"),
+        Column(name="FIBER", length=nrows, dtype=np.int32,
+               description="SPECTROGRAPH * 500 + SLITBLOCK * 25 + BLOCKFIBER"),
+        Column(name="OFFSET_X", length=nrows, dtype=np.float64,
+               description="X location of positioner center", unit="mm"),
+        Column(name="OFFSET_Y", length=nrows, dtype=np.float64,
+               description="Y location of positioner center", unit="mm"),
+        Column(name="OFFSET_T", length=nrows, dtype=np.float64,
+               description="THETA zero point angle", unit="degrees"),
+        Column(name="OFFSET_P", length=nrows, dtype=np.float64,
+               description="PHI zero point angle", unit="degrees"),
+        Column(name="LENGTH_R1", length=nrows, dtype=np.float64,
+               description="Length of THETA arm", unit="mm"),
+        Column(name="LENGTH_R2", length=nrows, dtype=np.float64,
+               description="Length of PHI arm", unit="mm"),
+        Column(name="MAX_T", length=nrows, dtype=np.float64,
+               description="Maximum THETA angle relative to OFFSET_T",
+               unit="degrees"),
+        Column(name="MIN_T", length=nrows, dtype=np.float64,
+               description="Minimum THETA angle relative to OFFSET_T",
+               unit="degrees"),
+        Column(name="MAX_P", length=nrows, dtype=np.float64,
+               description="Maximum PHI angle relative to OFFSET_P",
+               unit="degrees"),
+        Column(name="MIN_P", length=nrows, dtype=np.float64,
+               description="Minimum PHI angle relative to OFFSET_P",
+               unit="degrees"),
+        Column(name="EXCLUSION", length=nrows, dtype=np.dtype("a9"),
+               description="The exclusion polygon for this device"),
+    ]
+
+    out_fp = Table()
+    out_fp.add_columns(out_cols)
+
+    # Populate the table
+    dev_cols = [
+        "OFFSET_X",
+        "OFFSET_Y",
+        "OFFSET_T",
+        "OFFSET_P",
+        "LENGTH_R1",
+        "LENGTH_R2",
+        "MIN_T",
+        "MAX_T",
+        "MIN_P",
+        "MAX_P"
+    ]
+
+    row = 0
+    for petal in sorted(allpetals):
+        devlist = list(sorted(fp[petal].keys()))
+        for dev in devlist:
+            out_fp[row]["PETAL"] = fp[petal][dev]["PETAL"]
+            out_fp[row]["DEVICE"] = dev
+            out_fp[row]["LOCATION"] = fp[petal][dev]["PETAL"] * 1000 + dev
+            out_fp[row]["PETAL_ID"] = petal
+            out_fp[row]["DEVICE_ID"] = fp[petal][dev]["DEVICE_ID"]
+            out_fp[row]["DEVICE_TYPE"] = fp[petal][dev]["DEVICE_TYPE"]
+            out_fp[row]["SLITBLOCK"] = fp[petal][dev]["SLITBLOCK"]
+            out_fp[row]["BLOCKFIBER"] = fp[petal][dev]["BLOCKFIBER"]
+            out_fp[row]["SPECTROGRAPH"] = fp[petal][dev]["SPECTROGRAPH"]
+            out_fp[row]["EXCLUSION"] = fp[petal][dev]["EXCLUSION"]
+            if fp[pet][dev]["SLITBLOCK"] < 0:
+                # This must not be a POS device
+                out_fp[row]["FIBER"] = -1
+            else:
+                out_fp[row]["FIBER"] = \
+                    fp[petal][dev]["SPECTROGRAPH"] * 500 \
+                    + fp[petal][dev]["SLITBLOCK"] * 25 \
+                    + fp[petal][dev]["BLOCKFIBER"]
+            if fp[petal][dev]["DEVICE_ID"] != "NONE":
+                for col in dev_cols:
+                    if col in fp[petal][dev]:
+                        out_fp[row][col] = fp[petal][dev][col]
+            row += 1
+
+    out_fp.write(out_fp_file, format='ascii.ecsv')
+    del out_fp
+
+    # Now the state file.
+
+    out_cols = [
+        Column(name="TIME", length=nrows, dtype=np.dtype("a20"),
+               description="The timestamp of the event (UTC, ISO format)"),
+        Column(name="PETAL", length=nrows, dtype=np.int32,
+               description="Petal location [0-9]"),
+        Column(name="DEVICE", length=nrows, dtype=np.int32,
+               description="Device location on the petal"),
+        Column(name="STATE", length=nrows, dtype=np.uint32,
+               description="Bit field"),
+    ]
+
+    out_state = Table()
+    out_state.add_columns(out_cols)
+
+    row = 0
+    for petal in sorted(allpetals):
+        devlist = list(sorted(fp[petal].keys()))
+        for dev in devlist:
+            out_state[row]["TIME"] = file_date
+            out_state[row]["PETAL"] = fp[petal][dev]["PETAL"]
+            out_state[row]["DEVICE"] = dev
+            out_state[row]["STATE"] = 0
+            row += 1
+
+    out_state.write(out_state_file, format='ascii.ecsv')
+
+    # Now write out the exclusion polygons.  Since these are not tabular, we
+    # write to a YAML file.
+
+    with open(out_poly_file, "w") as pf:
+        yaml.dump(poly, pf, default_flow_style=False)
+
+    return

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -90,6 +90,11 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
     if posdir is None:
         fillfake = True
 
+    if fakefiberpos and (posdir is not None):
+        raise RuntimeError(
+            "Cannot specify both fake positioners from fiberpos and real"
+            " devices from posdir")
+
     if startvalid is None:
         startvalid = datetime.utcnow()
     else:
@@ -117,17 +122,18 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
     fp = dict()
 
     if fakefiberpos:
-        # Get the mapping from the fiberpos instead
+        # Get the mapping AND device info from the fiberpos instead
         fpos = load_fiberpos()
         # There is no "PETAL_ID" for the fake fiberpos, so we use PETAL
-        for pet, dev, blk, fib in zip(fpos["PETAL"], fpos["DEVICE"],
-                                      fpos["SLITBLOCK"], fpos["BLOCKFIBER"]):
+        for pet, dev, blk, fib, xoff, yoff in zip(
+                fpos["PETAL"], fpos["DEVICE"], fpos["SLITBLOCK"],
+                fpos["BLOCKFIBER"], fpos["X"], fpos["Y"]):
             allpetals.add(pet)
             if pet not in fp:
                 fp[pet] = dict()
             if dev not in fp[pet]:
                 empty = dict()
-                empty["DEVICE_ID"] = "NONE"
+                empty["DEVICE_ID"] = "FAKE"
                 fp[pet][dev] = empty
             fp[pet][dev]["SLITBLOCK"] = blk
             fp[pet][dev]["BLOCKFIBER"] = fib
@@ -136,6 +142,17 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
             fp[pet][dev]["FWHM"] = 0.0
             fp[pet][dev]["FRD"] = 0.0
             fp[pet][dev]["ABS"] = 0.0
+            fp[pet][dev]["DEVICE_ID"] = "FAKE"
+            fp[pet][dev]["OFFSET_X"] = xoff
+            fp[pet][dev]["OFFSET_Y"] = yoff
+            fp[pet][dev]["OFFSET_T"] = 0.0
+            fp[pet][dev]["OFFSET_P"] = 0.0
+            fp[pet][dev]["MIN_T"] = 0.0
+            fp[pet][dev]["MAX_T"] = 380.0
+            fp[pet][dev]["MIN_P"] = 0.0
+            fp[pet][dev]["MAX_P"] = 200.0
+            fp[pet][dev]["LENGTH_R1"] = 3.0
+            fp[pet][dev]["LENGTH_R2"] = 3.0
     else:
         for docnum, docver, docname in fibermaps:
             fmfile = None

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -44,7 +44,8 @@ def _compute_theta_phi_range(phys_t, phys_p):
 
 
 def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
-          petalloc=None, startvalid=None, fillfake=False, exclusion="legacy"):
+           petalloc=None, startvalid=None, fillfake=False, exclusion="legacy",
+           fakeoffset=False):
     """Construct DESI focalplane and state files.
 
     This function gathers information from the following sources:
@@ -70,6 +71,9 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
         fillfake (bool):  If True, fill missing device locations with fake
             positioners with nominal values for use in simulations.
         exclusion (str):  The name of the default exclusion polygons.
+        fakeoffset (bool):  If True, artificially sets the theta / phi angle
+            offsets to zero.  This replicates the behavior of legacy
+            fiberassign and should only be used for testing.
 
     Returns:
         None
@@ -277,8 +281,12 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
                         - np.sin(phi) * ynom
                     fp[petal][dev]["OFFSET_Y"] = np.sin(phi) * xnom \
                         + np.cos(phi) * ynom
-                    fp[petal][dev]["OFFSET_T"] = -170.0
-                    fp[petal][dev]["OFFSET_P"] = -5.0
+                    if fakeoffset:
+                        fp[petal][dev]["OFFSET_T"] = 0.0
+                        fp[petal][dev]["OFFSET_P"] = 0.0
+                    else:
+                        fp[petal][dev]["OFFSET_T"] = -170.0
+                        fp[petal][dev]["OFFSET_P"] = -5.0
                     fp[petal][dev]["LENGTH_R1"] = 3.0
                     fp[petal][dev]["LENGTH_R2"] = 3.0
                     fp[petal][dev]["MIN_T"] = t_min
@@ -342,6 +350,7 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
         ktheta.append(kstart)
         poly["default"]["theta"] = dict()
         poly["default"]["theta"]["segments"] = [ktheta]
+        poly["default"]["theta"]["circles"] = list()
         kphi_raw = np.transpose(np.array(exprops["KEEPOUT_PHI"]))
         kphi_x = kphi_raw[:, 0]
         kphi_y = kphi_raw[:, 1]
@@ -350,6 +359,7 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
         kphi.append(kstart)
         poly["default"]["phi"] = dict()
         poly["default"]["phi"]["segments"] = [kphi]
+        poly["default"]["phi"]["circles"] = list()
 
     # Now write out all of this collected information.  Also write out an
     # initial "state" log as a starting point.  Note that by having log

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -96,15 +96,15 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
     if fibermaps is None:
         fibermaps = [
             (4042, 5, "Petal_2_final_verification.csv"),
-            (4043, 6, "Petal_3_final_verification.csv"),
+            (4043, 7, "Petal_3_final_verification.csv"),
             (4807, 2, "Petal_4_final_verification.csv"),
             (4808, 3, "Petal_5_final_verification.csv"),
             (4809, 2, "Petal_6_final_verification.csv"),
             (4190, 6, "Petal_7_final_verification.csv"),
             (4806, 4, "Petal_8_final_verification.csv"),
             (4810, 3, "Petal_9_final_verification.csv"),
-            (4868, 3, "Petal_10_final_verification.csv"),
-            (4883, 3, "Petal_11_final_verification.csv")
+            (4868, 5, "Petal_10_final_verification.csv"),
+            (4883, 4, "Petal_11_final_verification.csv")
         ]
 
     # Process the fibermap files from DocDB.  We start with this step so that

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -284,15 +284,19 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
                     if fakeoffset:
                         fp[petal][dev]["OFFSET_T"] = 0.0
                         fp[petal][dev]["OFFSET_P"] = 0.0
+                        fp[petal][dev]["MIN_T"] = 0.0
+                        fp[petal][dev]["MAX_T"] = 380.0
+                        fp[petal][dev]["MIN_P"] = 0.0
+                        fp[petal][dev]["MAX_P"] = 200.0
                     else:
                         fp[petal][dev]["OFFSET_T"] = -170.0
                         fp[petal][dev]["OFFSET_P"] = -5.0
+                        fp[petal][dev]["MIN_T"] = t_min
+                        fp[petal][dev]["MAX_T"] = t_max
+                        fp[petal][dev]["MIN_P"] = p_min
+                        fp[petal][dev]["MAX_P"] = p_max
                     fp[petal][dev]["LENGTH_R1"] = 3.0
                     fp[petal][dev]["LENGTH_R2"] = 3.0
-                    fp[petal][dev]["MIN_T"] = t_min
-                    fp[petal][dev]["MAX_T"] = t_max
-                    fp[petal][dev]["MIN_P"] = p_min
-                    fp[petal][dev]["MAX_P"] = p_max
 
     # Now load the file(s) with the exclusion polygons
     # Add the legacy polygons to the dictionary for reference.
@@ -300,14 +304,14 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
 
     # First the THETA arm.
     circs = [
-        [[3.0, 0.0], 2.095]
+        [[0.0+3.0, 0.0], 2.095]
     ]
     seg = [
-        [5.095, -0.474],
-        [4.358, -2.5],
-        [2.771, -2.5],
-        [1.759, -2.792],
-        [0.905, -0.356]
+        [2.095+3.0, -0.474],
+        [1.358+3.0, -2.5],
+        [-0.229+3.0, -2.5],
+        [-1.241+3.0, -2.792],
+        [-2.095+3.0, -0.356]
     ]
     segs = [seg]
     shp_theta = dict()
@@ -316,18 +320,18 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
 
     # Now the PHI arm
     circs = [
-        [[0.0, 0.0], 0.967]
+        [[0.0+3.0, 0.0], 0.967]
     ]
     seg_upper = [
-        [-3.0, 0.990],
-        [0.0, 0.990]
+        [-3.0+3.0, 0.990],
+        [0.0+3.0, 0.990]
     ]
     seg_lower = [
-        [-2.944, -1.339],
-        [-2.944, -2.015],
-        [-1.981, -1.757],
-        [-1.844, -0.990],
-        [0.0, -0.990]
+        [-2.944+3.0, -1.339],
+        [-2.944+3.0, -2.015],
+        [-1.981+3.0, -1.757],
+        [-1.844+3.0, -0.990],
+        [0.0+3.0, -0.990]
     ]
     segs = [seg_upper, seg_lower]
     shp_phi = dict()
@@ -339,7 +343,7 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
     poly["legacy"]["phi"] = shp_phi
 
     if polyfile is not None:
-        # Add shapes from other files
+        # Add shapes from other files.  The convention used here for
         exprops = configobj.ConfigObj(polyfile, unrepr=True)
         poly["default"] = dict()
         ktheta_raw = np.transpose(np.array(exprops["KEEPOUT_THETA"]))

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -44,7 +44,7 @@ def _compute_theta_phi_range(phys_t, phys_p):
 
 
 def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
-          petalloc=None, petalspec=None, startvalid=None):
+          petalloc=None, petalspec=None, startvalid=None, fillfake=False):
     """Construct DESI focalplane and state files.
 
     This function gathers information from the following sources:
@@ -229,6 +229,30 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
             devlist = list(sorted(fp[petal].keys()))
             for dev in devlist:
                 fp[petal][dev]["SPECTROGRAPH"] = petalspec[petal]
+
+    # If the fillfake option is specified, fill all device locations of POS and
+    # ETC type with a fake positioner if there is none there.
+
+    if fillfake:
+        for petal in sorted(allpetals):
+            devlist = list(sorted(fp[petal].keys()))
+            for dev in devlist:
+                if fp[petal][dev]["DEVICE_ID"] == "NONE":
+
+
+
+            t_min, t_max, p_min, p_max = _compute_theta_phi_range(
+                props["PHYSICAL_RANGE_T"], props["PHYSICAL_RANGE_P"])
+            fp[pet][dev]["OFFSET_X"] = props["OFFSET_X"]
+            fp[pet][dev]["OFFSET_Y"] = props["OFFSET_Y"]
+            fp[pet][dev]["OFFSET_T"] = props["OFFSET_T"]
+            fp[pet][dev]["OFFSET_P"] = props["OFFSET_P"]
+            fp[pet][dev]["LENGTH_R1"] = props["LENGTH_R1"]
+            fp[pet][dev]["LENGTH_R2"] = props["LENGTH_R2"]
+            fp[pet][dev]["MIN_T"] = t_min
+            fp[pet][dev]["MAX_T"] = t_max
+            fp[pet][dev]["MIN_P"] = p_min
+            fp[pet][dev]["MAX_P"] = p_max
 
     # Now load the file(s) with the exclusion polygons
     # Add the legacy polygons to the dictionary for reference.

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -346,11 +346,13 @@ def load_focalplane(time):
             pet = fullstate[row]["PETAL"]
             dev = fullstate[row]["DEVICE"]
             st = fullstate[row]["STATE"]
+            excl = fullstate[row]["EXCLUSION"]
             if loc not in locstate:
                 locstate[loc] = dict()
             locstate[loc]["PETAL"] = pet
             locstate[loc]["DEVICE"] = dev
             locstate[loc]["STATE"] = st
+            locstate[loc]["EXCLUSION"] = excl
 
     nloc = len(locstate)
     state_cols = [
@@ -362,6 +364,8 @@ def load_focalplane(time):
                description="Global device location (PETAL * 1000 + DEVICE)"),
         Column(name="STATE", length=nloc, dtype=np.uint32,
                description="State bit field (good == 0)"),
+        Column(name="EXCLUSION", length=nloc, dtype=np.dtype("a9"),
+               description="The exclusion polygon for this device"),
     ]
     state_data = Table()
     state_data.add_columns(state_cols)
@@ -371,6 +375,7 @@ def load_focalplane(time):
         state_data[row]["DEVICE"] = locstate[loc]["DEVICE"]
         state_data[row]["LOCATION"] = loc
         state_data[row]["STATE"] = locstate[loc]["STATE"]
+        state_data[row]["EXCLUSION"] = locstate[loc]["EXCLUSION"]
         row += 1
 
     return (fp_data, excl_data, state_data)

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -305,7 +305,6 @@ def load_focalplane(time):
             break
         # Check that we have all 3 files needed for each timestamp
         for ts, files in fpraw.items():
-            print("Checking time {}".format(ts), flush=True)
             for key in ["fp", "st", "ex"]:
                 if key not in files:
                     msg = "Focalplane state for time {} is missing one of \

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -329,11 +329,13 @@ def load_focalplane(time):
     fp_data = None
     excl_data = None
     fullstate = None
+    tmstr = None
     for dt, fp, ex, st in _focalplane:
         if time > dt:
             fp_data = fp
             excl_data = ex
             fullstate = st
+            tmstr = dt.isoformat(timespec="seconds")
         else:
             break
 
@@ -378,7 +380,7 @@ def load_focalplane(time):
         state_data[row]["EXCLUSION"] = locstate[loc]["EXCLUSION"]
         row += 1
 
-    return (fp_data, excl_data, state_data)
+    return (fp_data, excl_data, state_data, tmstr)
 
 
 def reset_cache():


### PR DESCRIPTION
This work attempts to capture the "time-varying" nature of the focalplane properties and also unifies several sources of information.  There are two parts:

1.  desimodel.inputs.focalplane.create() and the entry point bin/generate_focalplane

    - Read the verified petal maps from DocDB
    - Read the pos_settings conf files
    - Read exclusion polygons
    - Optionally specify the petal ID --> Location mapping
    - Optionally specify the petal Location --> spectrograph mapping
    - Create a unified focalplane description consisting of 3 files:  a table of properties, a yaml file with the sets of exclusion polygons (positioners may use different polygons), and a starting "state" log.
    - The files are written to the desimodel data directory.

2.  desimodel.io.load_focalplane() which takes a datetime stamp.  This is used to lookup the most recent set of files that apply.  The state log is then "replayed" to the requested time, and the focalplane info for that time is returned.

In practice it would work like this:

1. Every time major changes happen (petal is modified, etc) a new set of files is generated.

2.  When a positioner state changes (stuck, broken, etc), a line is appended to the state log.

During commissioning and initial testing these files will be generated frequently, but that should stabilize rapidly.  One suggestion made previously was to remove the FIBER and SPECTROGRAPH columns all together from the hardware description, and to let those be solely determined by the fibermap from each exposure.

Attached are an example of the proposed focalplane file format.
[desi-focalplane_example.tar.gz](https://github.com/desihub/desimodel/files/3244475/desi-focalplane_example.tar.gz)

Comments / thoughts welcome.  In particular, opinions about removal of FIBER and SPECTROGRAPH, since that would allow the same set of files to remain valid even if a petal was plugged in to a different spectrograph.
