### PR TITLE
c-contiguous array for scipy 1.3 kdtree calc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
             - texlive-latex-extra
             - dvipng
 python:
-    - 2.7
+    # - 2.7
     - 3.5
     - 3.6
 env:
@@ -37,7 +37,7 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.9
         # - SCIPY_VERSION=0.14
-        - ASTROPY_VERSION=2.0.8
+        - ASTROPY_VERSION=2.0.14
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=1.9.13
         - SPECTER_VERSION=0.9.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        # - NUMPY_VERSION=1.9
+        - NUMPY_VERSION=1.15
         # - SCIPY_VERSION=0.14
         - ASTROPY_VERSION=2.0.14
         # - SPHINX_VERSION=1.6.6
@@ -48,7 +48,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy numba'
+        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy healpy numba'
+        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy numba'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
@@ -133,6 +133,7 @@ install:
     # egg_info causes the astropy/ci-helpers script to exit before the pip
     # packages are installed, thus desiutil is not installed in that script.
     - for p in $DESIHUB_PIP_DEPENDENCIES; do r=$(echo $p | cut -d= -f1); v=$(echo $p | cut -d= -f2); pip install git+https://github.com/desihub/${r}.git@${v}#egg=${r}; done
+    - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy; fi"
     - if [[ $SETUP_CMD == test* ]]; then source etc/desimodel_data.sh; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy numba'
+        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy numba blas=1.0=openblas'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy'
+        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy numba'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy numba'
+        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy healpy numba'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
@@ -72,7 +72,7 @@ matrix:
         - os: osx
         - os: linux
           python: 3.6
-          env: ASTROPY_VERSION=3.0
+          env: ASTROPY_VERSION='<4.0'
                SETUP_CMD='test'
                CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
                PIP_DEPENDENCIES=${PIP_ALL_DEPENDENCIES}
@@ -96,7 +96,7 @@ matrix:
 
         - os: linux
           python: 3.6
-          env: ASTROPY_VERSION=3.0
+          env: ASTROPY_VERSION='<4.0'
                SETUP_CMD='test'
                CONDA_DEPENDENCIES=${CONDA_ALL_DEPENDENCIES}
                PIP_DEPENDENCIES=${PIP_ALL_DEPENDENCIES}
@@ -133,7 +133,7 @@ install:
     # egg_info causes the astropy/ci-helpers script to exit before the pip
     # packages are installed, thus desiutil is not installed in that script.
     - for p in $DESIHUB_PIP_DEPENDENCIES; do r=$(echo $p | cut -d= -f1); v=$(echo $p | cut -d= -f2); pip install git+https://github.com/desihub/${r}.git@${v}#egg=${r}; done
-    - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy; fi"
+    # - "if [[ $SETUP_CMD == test* ]]; then pip install --no-binary :all: healpy; fi"
     - if [[ $SETUP_CMD == test* ]]; then source etc/desimodel_data.sh; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ dist: trusty
 addons:
     apt:
         packages:
-            - graphviz
+            # - graphviz
             - texlive-latex-extra
             - dvipng
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy numba blas=1.0=openblas'
+        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy numba'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -480,6 +480,9 @@ def is_point_in_desi(tiles, ra, dec, radius=None, return_tile_index=False):
     # radius to 3d distance
     threshold = 2.0 * np.sin(np.radians(radius) * 0.5)
     xyz = _embed_sphere(ra, dec)
+    if not xyz.flags['C_CONTIGUOUS']:
+        xyz = xyz.copy()
+
     d, i = tree.query(xyz, k=1)
 
     indesi = d < threshold
@@ -514,6 +517,9 @@ def find_tiles_over_point(tiles, ra, dec, radius=None):
     # radius to 3d distance
     threshold = 2.0 * np.sin(np.radians(radius) * 0.5)
     xyz = _embed_sphere(ra, dec)
+    if not xyz.flags['C_CONTIGUOUS']:
+        xyz = xyz.copy()
+
     indices = tree.query_ball_point(xyz, threshold)
     return indices
 
@@ -567,6 +573,9 @@ def find_points_radec(telra, teldec, ra, dec, radius = None):
     # radius to 3d distance
     threshold = 2.0 * np.sin(np.radians(radius) * 0.5)
     xyz = _embed_sphere(telra, teldec)
+    if not xyz.flags['C_CONTIGUOUS']:
+        xyz = xyz.copy()
+
     indices = tree.query_ball_point(xyz, threshold)
     return indices
 


### PR DESCRIPTION
This PR fixes a problem with `desimodel.footprint.find_points_radec`, `find_tiles_over_point`, and `is_point_in_desi` when using the kdtree code in scipy 1.3 which now requires that the input array of points is C-contiguous in memory.  Copying the array reshuffles the memory to become C-contiguous again.  This problem came up when testing with desiconda 20190730-1.3.0-spec which pulled in scipy 1.3.

I plan to self merge if/when Travis tests pass to be able to move on with the deployment, so holler quickly if you have an objection (or a better idea of how to handle this).