### PR TITLE
yaml.load -> yaml.safe_load

### DIFF
--- a/py/desimodel/inputs/throughput.py
+++ b/py/desimodel/inputs/throughput.py
@@ -43,7 +43,7 @@ def update(testdir=None, desi347_version=13, desi334_version=3):
     ccd_thru_file['z'] = docdb.download(334, desi334_version, 'nir-thru-250.txt')
 
     with open(desi_yaml_file) as fx:
-        params = yaml.load(fx)
+        params = yaml.safe_load(fx)
 
     if testdir is None:
         outfile_desiyaml = os.path.join(datadir(), 'desi.yaml')

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -67,7 +67,7 @@ def load_desiparams():
     if _params is None:
         desiparamsfile = os.path.join(os.environ['DESIMODEL'],'data','desi.yaml')
         with open(desiparamsfile) as par:
-            _params = yaml.load(par)
+            _params = yaml.safe_load(par)
 
         #- for temporary backwards compability after 'exptime' -> 'exptime_dark'
         if ('exptime' not in _params) and ('exptime_dark' in _params):
@@ -319,7 +319,7 @@ def load_focalplane(time):
             st = Table.read(fpraw[ts]["st"], format="ascii.ecsv")
             ex = None
             with open(fpraw[ts]["ex"], "r") as f:
-                ex = yaml.load(f)
+                ex = yaml.safe_load(f)
             _focalplane.append((dt, fp, ex, st))
 
     # Search the list of states for the most recent time that is before our
@@ -409,7 +409,7 @@ def load_target_info():
         targetsfile = os.path.join(datadir(),'targets','targets.dat')
 
     with open(targetsfile) as fx:
-        data = yaml.load(fx)
+        data = yaml.safe_load(fx)
 
     return data
 


### PR DESCRIPTION
Similar to desihub/desitarget#475, this PR replaces `yaml.load` with `yaml.safe_load` to get rid of deprecation warnings and clean things up before `yaml.load` completely disappears.  `yaml.safe_load` has been around since 2006, so I think we're safe with any versions of yaml that we might be using out in the wild.