### PR TITLE
Small changes for final latest svn pos_settings

### DIFF
--- a/bin/desi_generate_focalplane
+++ b/bin/desi_generate_focalplane
@@ -66,9 +66,10 @@ def main():
     petalloc = None
     if args.petal_id2loc is not None:
         petalloc = dict()
-        kv = args.petal_id2loc.split(",")
-        for k, v in kv.items():
-            petalloc[k] = v
+        ptl = args.petal_id2loc.split(",")
+        for pt in ptl:
+            k, v = pt.split(':')
+            petalloc[int(k)] = int(v)
 
     create(testdir=args.test, posdir=args.pos_settings,
            polyfile=args.collision, fibermaps=None, petalloc=petalloc,

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -257,6 +257,8 @@ def create(testdir=None, posdir=None, polyfile=None, fibermaps=None,
             props["PHYSICAL_RANGE_T"], props["PHYSICAL_RANGE_P"])
         # These values are incorrect in many cases.  Use nominal values
         # instead (see below).
+        # fp[pet][dev]["OFFSET_X"] = props["OFFSET_X"]
+        # fp[pet][dev]["OFFSET_Y"] = props["OFFSET_Y"]
         fp[pet][dev]["OFFSET_X"] = 0.0
         fp[pet][dev]["OFFSET_Y"] = 0.0
         fp[pet][dev]["OFFSET_T"] = props["OFFSET_T"]

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -280,6 +280,8 @@ def load_focalplane(time):
         stpat = re.compile(r"desi-state_(.*)\.ecsv")
         expat = re.compile(r"desi-exclusion_(.*)\.yaml")
         fpraw = dict()
+        msg = "Loading focalplanes from {}".format(fpdir)
+        log.debug(msg)
         for root, dirs, files in os.walk(fpdir):
             for f in files:
                 fpmat = fppat.match(f)
@@ -338,6 +340,10 @@ def load_focalplane(time):
             tmstr = dt.isoformat(timespec="seconds")
         else:
             break
+
+    if fullstate is None:
+        msg = "Cannot find focalplane for time {}".format(time)
+        raise RuntimeError(msg)
 
     # Now "replay" the state up to our requested time.
     locstate = dict()


### PR DESCRIPTION
Store petal and gfa keepouts in the focalplane model.  Use nominal positioner X/Y locations for now.  After these changes the last svn versions of the positioner properties can be imported.  Future changes to this script will focus on interfacing with the online DB.