### PR TITLE
Fix support for python 3.5 isoformat.

### DIFF
--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -337,7 +337,14 @@ def load_focalplane(time):
             fp_data = fp
             excl_data = ex
             fullstate = st
-            tmstr = dt.isoformat(timespec="seconds")
+            try:
+                tmstr = dt.isoformat(timespec="seconds")
+            except TypeError:
+                # This must be python < 3.6, with no timespec option.
+                # Since the focalplane time is read from the file name without
+                # microseconds, the microseconds should be zero and so the
+                # default return string will be correct.
+                tmstr = dt.isoformat()
         else:
             break
 


### PR DESCRIPTION
Older versions of python3 (< 3.6) do not support the timespec option to datetime.isoformat().  And the python3.6 version of this function requires the timespec option to produce a string with precision in seconds.  This small change supports both cases.