### PR TITLE
Workaround petal verification bugs.  Implement positioner rotation

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -9,6 +9,13 @@ desimodel Release Notes
   ``desi-healpix-weights.fits`` with new dither pattern; see DESI-0717.
   Layers 0=GRAY, 1-4=DARK instead of 0-3=DARK, 4=GRAY.
 
+0.10.1 (unreleased)
+-------------------
+
+* Workaround upstream bugs in positioner locations (PR `#118`_).
+
+.. _`#118`: https://github.com/desihub/desimodel/pull/118
+
 0.10.0 (2019-09-25)
 -------------------
 

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -262,16 +262,19 @@ def load_platescale():
 
 
 _focalplane = None
-def load_focalplane(time):
+def load_focalplane(time=None):
     """Load the focalplane state that is valid for the given time.
 
-    Args:
-        time (datetime):  The time to query.
+    Options:
+        time (datetime):  The time to query. default to current time.
 
     Returns:
-        (tuple):  The (focalplane layout, exclusion polygons, state log)
+        (tuple):  The (FP layout, exclusion polygons, state log, time string)
 
     """
+    if time is None:
+        time = datetime.now()
+
     global _focalplane
     if _focalplane is None:
         # First call, load all data files.


### PR DESCRIPTION
In addition to the fiber mapping fix, this fixes the rotation of positioners when placing petals at locations across the focalplane.  Fixes #117