### PR TITLE
When loading the plate scale, also read a new column for the S(R) arc length.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,8 @@ env:
         - DESIUTIL_VERSION=2.0.1
         - SPECTER_VERSION=0.9.1
         # This is the version of the svn data product to export.
-        - DESIMODEL_VERSION=branches/test-0.10
-        # - DESIMODEL_VERSION=trunk
+        # - DESIMODEL_VERSION=branches/test-0.10
+        - DESIMODEL_VERSION=trunk
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -257,8 +257,9 @@ def load_platescale():
         ('theta', 'f8'),
         ('radial_platescale', 'f8'),
         ('az_platescale', 'f8'),
+        ('arclength', 'f8'),
     ]
-    _platescale = np.loadtxt(infile, usecols=[0,1,6,7], dtype=columns)
+    _platescale = np.loadtxt(infile, usecols=[0,1,6,7,8], dtype=columns)
     return _platescale
 
 


### PR DESCRIPTION
This adds a small change to the load_platescale() function which also loads a newly added column of the arc length data S(R) from DESI-0530.

This PR **does not** change the actual XY <--> RS conversion routines.  However, once this column is loaded, it opens up the door to using that S(R) data for the interpolation.

There is in-progress fiberassign work that needs access to this arc length data, which is the motivation for adding it to the platescale.txt file and for reading it here.

Note that this PR requires current trunk of desimodel data svn (revision >= 129389), so should not be merged until we are ok with that requirement.