### PR TITLE
code to support newtiles, and S vs. R

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ env:
         - SPECTER_VERSION=0.9.1
         - PIP_VERSION=19.3.1
         # This is the version of the svn data product to export.
-        # - DESIMODEL_VERSION=branches/test-0.10
         - DESIMODEL_VERSION=trunk
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,9 @@ env:
         - SPECTER_VERSION=0.9.1
         - PIP_VERSION=19.3.1
         # This is the version of the svn data product to export.
-        - DESIMODEL_VERSION=trunk
+        # - DESIMODEL_VERSION=trunk
+        # - DESIMODEL_VERSION=branches/test-0.9.8
+        - DESIMODEL_VERSION=branches/newtiles
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -262,6 +262,13 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, outfile=None, outp
     '''
     t0 = time()
 
+    # ADM if tiles or radius is None, load the DESI model defaults.
+    if tiles is None:
+        tiles = load_tiles()
+
+    if radius is None:
+        radius = get_tile_radius_deg()
+
     #ADM create an array that is zero for each integer pixel at this nside
     import healpy as hp
     npix = hp.nside2npix(nside)
@@ -352,7 +359,7 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, outfile=None, outp
 
     #ADM find which random points in the fractional pixels are in the DESI footprint
     log.info('Start integration over fractional pixels at edges of DESI footprint...')
-    indesi = is_point_in_desi(load_tiles(),rainmask,decinmask)
+    indesi = is_point_in_desi(tiles,rainmask,decinmask)
     log.info('...{} of the random points in fractional pixels are in DESI...t={:.1f}s'
              .format(np.sum(indesi),time()-t0))
 

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -263,6 +263,7 @@ def pixweight(nside, tiles=None, radius=None, precision=0.01, outfile=None, outp
     t0 = time()
 
     # ADM if tiles or radius is None, load the DESI model defaults.
+    from .focalplane import get_tile_radius_deg
     if tiles is None:
         tiles = load_tiles()
 

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -259,7 +259,20 @@ def load_platescale():
         ('az_platescale', 'f8'),
         ('arclength', 'f8'),
     ]
-    _platescale = np.loadtxt(infile, usecols=[0,1,6,7,8], dtype=columns)
+    try:
+        _platescale = np.loadtxt(infile, usecols=[0,1,6,7,8], dtype=columns)
+    except IndexError:
+        #- no "arclength" column in this version of desimodel/data
+        #- Get info from separate rzs file instead
+
+        _platescale = np.loadtxt(infile, usecols=[0,1,6,7,7], dtype=columns)
+        rzs = Table.read(findfile('focalplane/rzsn.txt'), format='ascii')
+
+        from scipy.interpolate import interp1d
+        from numpy.lib.recfunctions import append_fields
+        arclength = interp1d(rzs['R'], rzs['S'], kind='quadratic')
+        _platescale['arclength'] = arclength(_platescale['radius'])
+
     return _platescale
 
 

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -286,10 +286,10 @@ class TestFootprint(unittest.TestCase):
         hirespixels = partpix64*16+np.arange(16)
         hiresweight = np.mean(pixweight256[hirespixels])
         loresweight = pixweight64[partpix64]
-        #ADM really they should agree to much better than 12%. As "precision" is not set to be
+        #ADM really they should agree to much better than 11%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
         #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
-        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.12))
+        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.11))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -78,6 +78,15 @@ class TestFootprint(unittest.TestCase):
         for p in passes:
             self.assertNotEqual(p, None)
 
+    def test_ecsv(self):
+        """Test consistency of ecsv vs. fits tiles files"""
+        t1 = Table.read(os.path.expandvars('$DESIMODEL/data/footprint/desi-tiles.fits'))
+        t2 = Table.read(os.path.expandvars('$DESIMODEL/data/footprint/desi-tiles.ecsv'),
+            format='ascii.ecsv')
+        for colname in t2.colnames:
+            self.assertIn(colname, t1.colnames)
+            self.assertTrue(np.all(t1[colname] == t2[colname]))
+
     def test_get_tile_radec(self):
         """Test grabbing tile information by tileID.
         """

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -29,25 +29,25 @@ class TestFootprint(unittest.TestCase):
     def test_pass2program(self):
         '''Test footprint.pass2program().
         '''
-        self.assertEqual(footprint.pass2program(0), 'DARK')
+        self.assertEqual(footprint.pass2program(0), 'GRAY')
         self.assertEqual(footprint.pass2program(1), 'DARK')
         self.assertEqual(footprint.pass2program(2), 'DARK')
         self.assertEqual(footprint.pass2program(3), 'DARK')
-        self.assertEqual(footprint.pass2program(4), 'GRAY')
+        self.assertEqual(footprint.pass2program(4), 'DARK')
         self.assertEqual(footprint.pass2program(5), 'BRIGHT')
         self.assertEqual(footprint.pass2program(6), 'BRIGHT')
         self.assertEqual(footprint.pass2program(7), 'BRIGHT')
 
         passes = [0,1,2,3,4,5,6,7]
-        programs = ['DARK', 'DARK', 'DARK', 'DARK', 'GRAY', 'BRIGHT', 'BRIGHT', 'BRIGHT']
+        programs = ['GRAY', 'DARK', 'DARK', 'DARK', 'DARK', 'BRIGHT', 'BRIGHT', 'BRIGHT']
         tmp = footprint.pass2program(passes)
         self.assertEqual(tmp, programs)
 
         tmp = footprint.pass2program(np.array(passes))
         self.assertEqual(tmp, programs)
 
-        tmp = footprint.pass2program([0,0,1])
-        self.assertEqual(tmp, ['DARK', 'DARK', 'DARK'])
+        tmp = footprint.pass2program([0,0,1,2])
+        self.assertEqual(tmp, ['GRAY', 'GRAY', 'DARK', 'DARK'])
 
         with self.assertRaises(KeyError):
             footprint.pass2program(999)
@@ -55,12 +55,12 @@ class TestFootprint(unittest.TestCase):
     def test_program2pass(self):
         '''Test footprint.program2pass().
         '''
-        self.assertEqual(footprint.program2pass('DARK'), [0,1,2,3])
-        self.assertEqual(footprint.program2pass('GRAY'), [4,])
+        self.assertEqual(footprint.program2pass('DARK'), [1,2,3,4])
+        self.assertEqual(footprint.program2pass('GRAY'), [0,])
         self.assertEqual(footprint.program2pass('BRIGHT'), [5,6,7])
-        self.assertEqual(footprint.program2pass(['DARK', 'GRAY']), [[0,1,2,3], [4,]])
+        self.assertEqual(footprint.program2pass(['DARK', 'GRAY']), [[1,2,3,4], [0,]])
         self.assertEqual(footprint.program2pass(np.array(['DARK', 'GRAY'])),
-                                                [[0,1,2,3], [4,]])
+                                                [[1,2,3,4], [0,]])
         with self.assertRaises(ValueError):
             footprint.program2pass('BLAT')
 
@@ -286,10 +286,10 @@ class TestFootprint(unittest.TestCase):
         hirespixels = partpix64*16+np.arange(16)
         hiresweight = np.mean(pixweight256[hirespixels])
         loresweight = pixweight64[partpix64]
-        #ADM really they should agree to much better than 11%. As "precision" is not set to be
+        #ADM really they should agree to much better than 12%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
         #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
-        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.11))
+        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.12))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -248,7 +248,7 @@ class TestFootprint(unittest.TestCase):
         #ADM I found a full (170) partial (406) and empty (1000) HEALPixel at nside=256
         #ADM that are also full, partial, empty at nside=64.
         #ADM You can find these with, e.g.:
-        #ADM pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.04)
+        #ADM pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.01)
         #ADM np.where(pixweight256 == 1)
         fullpix256 = np.array([170])
         partpix256 = np.array([406])
@@ -275,8 +275,8 @@ class TestFootprint(unittest.TestCase):
         radius = 1.605
 
         #ADM determine the weight array for pixels at nsides of 64 and 256
-        pixweight64 = footprint.pixweight(64,tiles=tiles,radius=radius,precision=0.04)
-        pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.04)
+        pixweight64 = footprint.pixweight(64,tiles=tiles,radius=radius,precision=0.01)
+        pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.01)
 
         #ADM check that the full pixel is assigned a weight of 1 at each nside
         self.assertTrue(np.all(pixweight64[fullpix64]==1))
@@ -290,11 +290,11 @@ class TestFootprint(unittest.TestCase):
         hirespixels = partpix64*16+np.arange(16)
         hiresweight = np.mean(pixweight256[hirespixels])
         loresweight = pixweight64[partpix64]
-        #ADM really they should agree to much better than 10%. As "precision" is not set to be
+        #ADM really they should agree to much better than 2%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
-        #ADM I checked that at precision = 0.04 this doesn't fail after 1000 attempts
-        #ADM (the largest difference I encountered was 0.078)
-        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.1))
+        #ADM I checked that at precision = 0.01 this doesn't fail after 1000 attempts
+        #ADM (the largest difference I encountered was 0.015)
+        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.02))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -4,6 +4,7 @@
 """
 import unittest
 import os
+from collections import Counter
 import numpy as np
 from astropy.table import Table
 
@@ -29,25 +30,23 @@ class TestFootprint(unittest.TestCase):
     def test_pass2program(self):
         '''Test footprint.pass2program().
         '''
-        self.assertEqual(footprint.pass2program(0), 'GRAY')
-        self.assertEqual(footprint.pass2program(1), 'DARK')
-        self.assertEqual(footprint.pass2program(2), 'DARK')
-        self.assertEqual(footprint.pass2program(3), 'DARK')
-        self.assertEqual(footprint.pass2program(4), 'DARK')
-        self.assertEqual(footprint.pass2program(5), 'BRIGHT')
-        self.assertEqual(footprint.pass2program(6), 'BRIGHT')
-        self.assertEqual(footprint.pass2program(7), 'BRIGHT')
+        programs = footprint.pass2program(list(range(8)))
+        count_layers = Counter(programs)
+        self.assertEqual(count_layers['DARK'], 4)
+        self.assertEqual(count_layers['GRAY'], 1)
+        self.assertEqual(count_layers['BRIGHT'], 3)
+        self.assertEqual(set(programs), set(['DARK', 'GRAY', 'BRIGHT']))
 
-        passes = [0,1,2,3,4,5,6,7]
-        programs = ['GRAY', 'DARK', 'DARK', 'DARK', 'DARK', 'BRIGHT', 'BRIGHT', 'BRIGHT']
-        tmp = footprint.pass2program(passes)
-        self.assertEqual(tmp, programs)
+        #- confirm that it works with multiple kinds of input
+        p0 = footprint.pass2program(0)
+        p1 = footprint.pass2program(1)
+        p01a = footprint.pass2program([0,1])
+        p01b = footprint.pass2program(np.array([0,1]))
+        self.assertEqual([p0,p1], p01a)
+        self.assertEqual([p0,p1], p01b)
 
-        tmp = footprint.pass2program(np.array(passes))
-        self.assertEqual(tmp, programs)
-
-        tmp = footprint.pass2program([0,0,1,2])
-        self.assertEqual(tmp, ['GRAY', 'GRAY', 'DARK', 'DARK'])
+        p011 = footprint.pass2program([0,1,1])
+        self.assertEqual([p0,p1,p1], p011)
 
         with self.assertRaises(KeyError):
             footprint.pass2program(999)
@@ -55,12 +54,16 @@ class TestFootprint(unittest.TestCase):
     def test_program2pass(self):
         '''Test footprint.program2pass().
         '''
-        self.assertEqual(footprint.program2pass('DARK'), [1,2,3,4])
-        self.assertEqual(footprint.program2pass('GRAY'), [0,])
-        self.assertEqual(footprint.program2pass('BRIGHT'), [5,6,7])
-        self.assertEqual(footprint.program2pass(['DARK', 'GRAY']), [[1,2,3,4], [0,]])
-        self.assertEqual(footprint.program2pass(np.array(['DARK', 'GRAY'])),
-                                                [[1,2,3,4], [0,]])
+        self.assertEqual(len(footprint.program2pass('DARK')), 4)
+        self.assertEqual(len(footprint.program2pass('GRAY')), 1)
+        self.assertEqual(len(footprint.program2pass('BRIGHT')), 3)
+
+        passes = footprint.program2pass(['DARK', 'GRAY', 'BRIGHT'])
+        self.assertEqual(len(passes), 3)
+        self.assertEqual(len(passes[0]), 4)
+        self.assertEqual(len(passes[1]), 1)
+        self.assertEqual(len(passes[2]), 3)
+
         with self.assertRaises(ValueError):
             footprint.program2pass('BLAT')
 

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -245,8 +245,12 @@ class TestFootprint(unittest.TestCase):
                                       ('PROGRAM', (str, 6)),
                                   ])
 
-        #ADM I found a full (180) partial (406) and empty (1000) HEALPixel at nside=256
-        fullpix256 = np.array([180])
+        #ADM I found a full (170) partial (406) and empty (1000) HEALPixel at nside=256
+        #ADM that are also full, partial, empty at nside=64.
+        #ADM You can find these with, e.g.:
+        #ADM pixweight256 = footprint.pixweight(256,tiles=tiles,radius=radius,precision=0.04)
+        #ADM np.where(pixweight256 == 1)
+        fullpix256 = np.array([170])
         partpix256 = np.array([406])
         emptypix256 = np.array([1000])
         #ADM In the nested scheme you can traverse from 256 to 64 by integer division
@@ -286,10 +290,11 @@ class TestFootprint(unittest.TestCase):
         hirespixels = partpix64*16+np.arange(16)
         hiresweight = np.mean(pixweight256[hirespixels])
         loresweight = pixweight64[partpix64]
-        #ADM really they should agree to much better than 11%. As "precision" is not set to be
+        #ADM really they should agree to much better than 10%. As "precision" is not set to be
         #ADM very high, this is just to check for catastrophic differences
-        #ADM I checked that at precision = 0.04 this doesn't fail after 10000 attempts
-        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.11))
+        #ADM I checked that at precision = 0.04 this doesn't fail after 1000 attempts
+        #ADM (the largest difference I encountered was 0.078)
+        self.assertTrue(np.all(np.abs(hiresweight-loresweight) < 0.1))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_spatial_real_tiles(self):

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -228,15 +228,20 @@ class TestIO(unittest.TestCase):
         tf = io.load_tiles(onlydesi=False, extra=True)
         tt = Table.read(fitstiles)
         te = Table.read(ecsvtiles, format='ascii.ecsv')
+
         self.assertEqual(sorted(tf.dtype.names), sorted(tt.colnames))
-        self.assertEqual(sorted(tf.dtype.names), sorted(te.colnames))
+
+        #- ECSV is a subset of the columns
+        missing = set(te.colnames) - set(tf.dtype.names)
+        self.assertEqual(len(missing), 0)
 
         for col in tt.colnames:
             self.assertTrue(np.all(tf[col]==tt[col]), 'fits[{col}] != table[{col}]'.format(col=col))
-            if np.issubdtype(tf[col].dtype, np.floating):
-                self.assertTrue(np.allclose(tf[col], te[col], atol=1e-4, rtol=1e-4), 'fits[{col}] != ecsv[{col}]'.format(col=col))
-            else:
-                self.assertTrue(np.all(tf[col]==te[col]), 'fits[{col}] != ecsv[{col}]'.format(col=col))
+            if col in te.colnames:
+                if np.issubdtype(tf[col].dtype, np.floating):
+                    self.assertTrue(np.allclose(tf[col], te[col], atol=1e-4, rtol=1e-4), 'fits[{col}] != ecsv[{col}]'.format(col=col))
+                else:
+                    self.assertTrue(np.all(tf[col]==te[col]), 'fits[{col}] != ecsv[{col}]'.format(col=col))
 
         for program in set(tf['PROGRAM']):
             self.assertTrue((program[-1] != ' ') and (program[-1] != b' '))

--- a/py/desimodel/trim.py
+++ b/py/desimodel/trim.py
@@ -72,6 +72,12 @@ def trim_footprint(indir, outdir):
     ii = (35 < t['RA']) & (t['RA'] < 55) & (-10 < t['DEC']) & (t['DEC'] < 20)
     tx = t[ii]
     tx.write(outfile, format='fits')
+
+    #- Remove multidimensional columns before writing ecsv
+    for colname in ['BRIGHTRA', 'BRIGHTDEC', 'BRIGHTVTMAG']:
+        if colname in tx.colnames:
+            tx.remove_column(colname)
+
     tx.write(outfile.replace('.fits', '.ecsv'), format='ascii.ecsv')
     infile, outfile = inout(indir, outdir, 'desi-healpix-weights.fits')
     # Use a low precision to speed up the calculation.  Use lower nside


### PR DESCRIPTION
This PR provides code to match @schlafly's "new" tiling pattern in svn desimodel/branches/newtiles .  That branch of the desimodel data expanded the format of the tiles file which broke some of the desimodel code (e.g. multi-dimensional columns), so this adapts to that.  I also updated the tests to support both current trunk and the newtiles branch.

Another change that came along for the ride is splitting out the S vs. R vs. Z vs. N data from DESI-0530 into a separate file (in the newtiles branch) instead of adding S (arclength) as a new column in the platescale.txt file (trunk).  The code here is compatible with either, but paves the way to update platescale.txt with the as-built model from DESI-4037 (issue #134) without breaking fiberassign.

@tskisner please review for fiberassign impacts.

@schlafly ok?

This PR replaces PR #95 that I just closed.