### PR TITLE
update platescale to as-built DESI-4037v6

### DIFF
--- a/py/desimodel/focalplane/geometry.py
+++ b/py/desimodel/focalplane/geometry.py
@@ -81,6 +81,12 @@ def get_radius_deg(x, y):
     :class:`float`
         Radius corresponding to `x`, `y`.
     """
+    #- support scalars, lists, and arrays
+    if not np.isscalar(x):
+        x = np.asarray(x)
+    if not np.isscalar(y):
+        y = np.asarray(y)
+
     radius = np.sqrt(x**2 + y**2)
     platescale = load_platescale()
     fn = interp1d(platescale['radius'], platescale['theta'],


### PR DESCRIPTION
This PR documents a change I'd like to make to svn desimodel/trunk/data/focalplane/platescale.txt to use the as-built optics from DESI-4037v6 instead of the as-designed optics in DESI-0329.  It also updates the unit tests to support the new model (the previous tests were checking the old model with extreme precision...).  This results in a ~150 um / 2.0 arcsec shift in the mapping between focalplane radius and angle on the sky:
![platescale-diff](https://user-images.githubusercontent.com/218471/76645589-8eeffd80-6516-11ea-9b5a-d00119a71bfe.png)
Note that this is within the 200 um buffer that fiberassign includes to absorb discrepancies with platemaker, but we shouldn't use up most of that budget with an easily correctable term, and it will have some impact (hopefully positive!) when running both ICS and fiberassign with the restricted angular reach, for which we did not include an extra 200 um buffer.

Since we have multiple updates under discussion, a note of clarification: this affects the mapping of angle on the sky to focal plane mm.  It does not change the model of where the positioners are on the focal plane.

I have not yet push the data change to svn, but it is basically replacing platescale.txt with DESI-4037v8 "DESI-4037 Telescope params - v2.txt" ([link](https://desi.lbl.gov/DocDB/cgi-bin/private/RetrieveFile?docid=4037;filename=DESI-4037%20Telescope%20params%20-%20v2.txt;version=8))

I'll leave this PR open for a ~hour while chasing other updates, then merge and update svn if there are no objections.

I'll mention @tskisner @djschlegel @Srheft to have this on their radar, though it shouldn't require any changes to fiberassign code itself.