### PR TITLE
Fixes for 2 small corner cases.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,10 +10,13 @@ desimodel Release Notes
 0.12.0 (2020-03-13)
 -------------------
 
-* update platescale to as-built DESI-4037v5 (PR `#1361`_).
+* update platescale to as-built DESI-4037v5 (PR `#136`_).
 * update desi-focalplane model for limited phi range 20200306 (svn data).
+* fix bug in generating focalplane model from old fiberpos files (PR `#139`_).
+* use >= not > when comparing runtime to focalplane model `#139`_).
 
 .. _`#136`: https://github.com/desihub/desimodel/pull/136
+.. _`#139`: https://github.com/desihub/desimodel/pull/139
 
 0.11.0 (2020-03-13)
 -------------------

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -75,7 +75,7 @@ def devices_from_fiberpos(fp):
         fp[pet][dev]["MIN_P"] = 0.0
         fp[pet][dev]["LENGTH_R1"] = 0.0
         fp[pet][dev]["LENGTH_R2"] = 0.0
-        if (devtyp != "POS") and (devtyp != "ETC"):
+        if (devtyp == "POS") or (devtyp == "ETC"):
             # This is a positioner.
             fp[pet][dev]["MAX_T"] = 380.0
             fp[pet][dev]["MAX_P"] = 200.0
@@ -671,10 +671,10 @@ def create(testdir=None, posdir=None, fibermaps=None,
     out_state_file = os.path.join(
         outdir, "desi-state_{}.ecsv".format(file_date))
 
-    out_fp.write(out_fp_file, format="ascii.ecsv")
+    out_fp.write(out_fp_file, format="ascii.ecsv", overwrite=True)
     del out_fp
 
-    out_state.write(out_state_file, format="ascii.ecsv")
+    out_state.write(out_state_file, format="ascii.ecsv", overwrite=True)
     del out_state
 
     # Now write out the exclusion polygons.  Since these are not tabular, we

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -428,7 +428,7 @@ def load_focalplane(time=None):
     fullstate = None
     tmstr = None
     for dt, fp, ex, st in _focalplane:
-        if time > dt:
+        if time >= dt:
             fp_data = fp
             excl_data = ex
             fullstate = st


### PR DESCRIPTION
This fixes two small issues:

  1.  If the runtime requested for a focalplane is exactly the
      time at which a new focalplane model becomes valid, then
      select the later model (use >=, not >).

  2.  In the case of generating a focalplane model from the old
      fiberpos files (which is no longer done and was only used
      in the past for debugging), fix a logic error.  This error
      was introduced *after* the original "legacy" focalplane
      version was created when this focalplane format was being
      developed.

Also add the overwrite option to astropy ecsv writing calls.