### PR TITLE
py3.8 syntax warnings

### DIFF
--- a/py/desimodel/inputs/throughput.py
+++ b/py/desimodel/inputs/throughput.py
@@ -20,7 +20,7 @@ from ..io import datadir, findfile
 
 def update(testdir=None, desi347_version=16, desi5501_version=3, desi5501_KOSI=True):
     '''
-    Update thru-\*.fits from DESI-0347 and DESI-0344
+    Update thru-[brz].fits from DESI-0347 and DESI-0344
 
     Args:
         testdir: If not None, write files here instead of standard locations

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -52,7 +52,7 @@ def svn_export(desimodel_version=None):
     from . import __version__ as this_version
     if desimodel_version is None:
         export_version = 'trunk'
-    elif desimodel_version is 'trunk' or 'branches/' in desimodel_version:
+    elif (desimodel_version == 'trunk') or ('branches/' in desimodel_version):
         export_version = desimodel_version
     else:
         export_version = 'tags/' + desimodel_version


### PR DESCRIPTION
Small syntax changes to keep python 3.8 happy:
  * docstrings can't use `thru-\*.fits` to prevent sphinx from interpreting the `*` as
    emphasis markup, because py3.8 complains that is an invalid escape sequence.
  * `blat is None` is ok, but `blat is 42` generates a SyntaxWarning (works in CPython by accident, but isn't guaranteed by language spec)
  * for the record: I added some extra parentheses for clarity, but they aren't strictly necessary.

Assigning to @weaverba137 for any commentary about how to express wildcards in docstrings while keeping both sphinx and py3.8 happy.  In this case I just avoided using it at all, but I'm not sure if there is a better general solution if you really do want to express a "*" in a docstring.