### PR TITLE
travis test with old healpy for old astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ env:
         - NUMPY_VERSION=1.15
         # - SCIPY_VERSION=0.14
         - ASTROPY_VERSION=2.0.16
+        #- Old healpy version needed as long as we pin old astropy too
+        - HEALPY_VERSION=1.12.9
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=2.0.1
         - SPECTER_VERSION=0.9.1
@@ -49,7 +51,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy healpy numba'
+        - CONDA_ALL_DEPENDENCIES='requests pyyaml scipy healpy=${HEALPY_VERSION} numba'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.


### PR DESCRIPTION
fix travis tests by pinning to an old healpy version to match the old astropy version.