### PR TITLE
Add a couple commandline scripts which previously existed in svn.

### DIFF
--- a/bin/desimodel_extend_exclusions
+++ b/bin/desimodel_extend_exclusions
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+"""Commandline script to extend a nominal set of exclusion polygons.
+
+This script DOES NOT touch any focalplane files.  It works with the lower-level input
+files that are passed to the desi_generate_focalplane script.
+
+"""
+
+import argparse
+
+import numpy as np
+
+import matplotlib.pyplot as plt
+
+
+from configobj import ConfigObj
+
+
+def raw_to_xy(obj):
+    raw = np.array(obj)
+    x = np.array(raw[0])
+    y = np.array(raw[1])
+    return {"x": x, "y": y}
+
+def xy_to_raw(xy):
+    raw = list()
+    raw.append(list(xy["x"]))
+    raw.append(list(xy["y"]))
+    return raw
+
+
+def load_exclusions(path):
+    raw = ConfigObj(infile=path, unrepr=True)
+    excl = dict()
+    excl["name"] = raw["NAME"]
+    excl["theta"] = raw_to_xy(raw["KEEPOUT_THETA"])
+    excl["phi"] = raw_to_xy(raw["KEEPOUT_PHI"])
+    excl["gfa"] = raw_to_xy(raw["KEEPOUT_GFA"])
+    excl["petal"] = raw_to_xy(raw["KEEPOUT_PTL"])
+    return excl
+
+
+def dump_exclusions(excl, path):
+    raw = ConfigObj(infile=None, unrepr=True)
+    raw.filename = path
+    raw.list_values = True
+    raw["NAME"] = excl["name"]
+    raw["KEEPOUT_THETA"] = xy_to_raw(excl["theta"])
+    raw["KEEPOUT_PHI"] = xy_to_raw(excl["phi"])
+    raw["KEEPOUT_GFA"] = xy_to_raw(excl["gfa"])
+    raw["KEEPOUT_PTL"] = xy_to_raw(excl["petal"])
+    raw.write()
+    return
+
+
+def extendpoly(xdata, ydata, dist):
+    xnew = list()
+    ynew = list()
+    ndat = len(xdata)
+    # For each point, compute the direction orthogonal to the line
+    # connecting the previous and next points.  Then move the
+    # current point along that direction.
+    for i in range(ndat):
+        prv = None
+        nxt = None
+        if i == 0:
+            nxt = i + 1
+            prv = -1
+        elif i == ndat - 1:
+            nxt = 0
+            prv = i - 1
+        else:
+            nxt = i + 1
+            prv = i - 1
+        tang = np.arctan2(ydata[nxt] - ydata[prv], xdata[nxt] - xdata[prv])
+        # print("{}:  prev {} ({}, {}) --> next {} ({}, {}) angle = {}".format(
+        #     i, prv, xdata[prv], ydata[prv], nxt, xdata[nxt], ydata[nxt], tang*180.0/np.pi)
+        # )
+        tang -= 0.5 * np.pi
+        xincr = dist * np.cos(tang)
+        yincr = dist * np.sin(tang)
+        # print("  radang = {}, xincr = {}, yincr = {}".format(tang, xincr, yincr))
+        xnew.append(xdata[i] + xincr)
+        ynew.append(ydata[i] + yincr)
+    return np.array(xnew), np.array(ynew)
+
+
+def plot_poly(ax, x, y, color="black"):
+    fullx = np.empty(len(x) + 1)
+    fullx[0:-1] = x
+    fullx[-1] = x[0]
+    fully = np.empty(len(y) + 1)
+    fully[0:-1] = y
+    fully[-1] = y[0]
+    ax.plot(fullx, fully, color=color)
+    return
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--original",
+        type=str,
+        default=None,
+        required=True,
+        help="The original exclusions conf file"
+    )
+
+    parser.add_argument(
+        "--increase",
+        type=int,
+        default=100,
+        required=False,
+        help="The amount (in microns) to extend the polygons"
+    )
+
+    parser.add_argument(
+        "--name",
+        type=str,
+        default=None,
+        required=False,
+        help="The name of the new exclusion polygons.  This should be short."
+    )
+
+    parser.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        required=False,
+        help="The output filename."
+    )
+
+    args = parser.parse_args()
+
+    if args.name is None:
+        # construct name from the increase
+        args.name = "plus{}".format(args.increase)
+
+    if args.out is None:
+        args.out = "exclusions_{}.conf".format(args.name)
+
+    # Load original polygons
+    orig = load_exclusions(args.original)
+
+    # Add to theta / phi exclusions
+
+    p = dict()
+    p["name"] = args.name
+    p["gfa"] = orig["gfa"]
+    p["petal"] = orig["petal"]
+    p["theta"] = dict()
+    p["theta"]["x"], p["theta"]["y"] = extendpoly(
+        orig["theta"]["x"], orig["theta"]["y"], (args.increase / 1000.0)
+    )
+    p["phi"] = dict()
+    p["phi"]["x"], p["phi"]["y"] = extendpoly(
+        orig["phi"]["x"], orig["phi"]["y"], (args.increase / 1000.0)
+    )
+
+    dump_exclusions(p, args.out)
+
+    # Plot a comparison
+
+    fig = plt.figure(figsize=(8, 6), dpi=100)
+    ax = fig.add_subplot(1, 1, 1)
+    plot_poly(ax, orig["phi"]["x"], orig["phi"]["y"], color="black")
+    plot_poly(ax, p["phi"]["x"], p["phi"]["y"], color="red")
+
+    plt.savefig("{}.png".format(args.out))
+    #plt.show()
+    plt.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/desimodel_restrict_positioners
+++ b/bin/desimodel_restrict_positioners
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+"""Commandline script to take a nominal focalplane model and produce a new model
+with a restricted patrol radius.
+
+This script loads an existing focalplane model and creates a new date-stamped model
+in the current $DESIMODEL data directory.
+
+"""
+
+import sys
+import datetime
+import argparse
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+import yaml
+
+from astropy.table import Table, Column
+
+from desimodel.io import load_focalplane
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--in_date",
+        type=str,
+        default=None,
+        required=False,
+        help="Input date in ISO format (e.g. '2020-01-01T00:00:00')."
+    )
+
+    parser.add_argument(
+        "--out_date",
+        type=str,
+        default=None,
+        required=False,
+        help="Output date in ISO format (e.g. '2020-01-01T00:00:00').  Default = now."
+    )
+
+    parser.add_argument(
+        "--reach",
+        type=float,
+        default=None,
+        required=True,
+        help="The maximum positioner reach in millimeters."
+    )
+
+    args = parser.parse_args()
+
+    in_time = None
+    if args.in_date is None:
+        in_time = datetime.datetime.now()
+    else:
+        in_time = datetime.datetime.strptime(args.in_date, "%Y-%m-%dT%H:%M:%S")
+
+    if args.out_date is None:
+        args.out_date = datetime.datetime.isoformat(
+            datetime.datetime.now()
+        )
+
+    # Load the starting focalplane model
+
+    fp, excl, state, in_tmstr = load_focalplane(in_time)
+
+    # Restrict the effective patrol radius by putting limits on the phi
+    # angle range.
+
+    nrows = len(fp)
+    for row in fp:
+        theta_arm = row["LENGTH_R1"]
+        phi_arm = row["LENGTH_R2"]
+        if theta_arm <= 0 or phi_arm <= 0:
+            # this is not a positioner
+            continue
+        phi_zero = np.radians(row["OFFSET_P"])
+        phi_min = np.radians(row["MIN_P"])
+        phi_max = np.radians(row["MAX_P"])
+        # Use law of cosines to find max opening angle
+        opening = np.degrees(
+            np.arccos(
+                (args.reach**2 - theta_arm**2 - phi_arm**2) /
+                (-2.0 * theta_arm * phi_arm)
+            )
+        )
+        # Phi min is relative to the offset
+        row["MIN_P"] = (180.0 - opening) - row["OFFSET_P"]
+
+    out_fp_file = "desi-focalplane_{}.ecsv".format(args.out_date)
+    out_excl_file = "desi-exclusion_{}.yaml".format(args.out_date)
+    out_state_file = "desi-state_{}.ecsv".format(args.out_date)
+
+    fp.write(out_fp_file, format="ascii.ecsv", overwrite=True)
+
+    out_cols = [
+        Column(name="TIME", length=nrows, dtype=np.dtype("a20"),
+               description="The timestamp of the event (UTC, ISO format)"),
+        Column(name="PETAL", length=nrows, dtype=np.int32,
+               description="Petal location [0-9]"),
+        Column(name="DEVICE", length=nrows, dtype=np.int32,
+               description="Device location on the petal"),
+        Column(name="LOCATION", length=nrows, dtype=np.int32,
+               description="Global device location (PETAL * 1000 + DEVICE)"),
+        Column(name="STATE", length=nrows, dtype=np.uint32,
+               description="State bit field (good == 0)"),
+        Column(name="EXCLUSION", length=nrows, dtype=np.dtype("a9"),
+               description="The exclusion polygon for this device"),
+    ]
+
+    out_state = Table()
+    out_state.add_columns(out_cols)
+    out_state["TIME"][:] = args.out_date
+    out_state["PETAL"][:] = state["PETAL"]
+    out_state["DEVICE"][:] = state["DEVICE"]
+    out_state["LOCATION"][:] = state["LOCATION"]
+    out_state["STATE"][:] = state["STATE"]
+    out_state["EXCLUSION"][:] = state["EXCLUSION"]
+
+    out_state.write(out_state_file, format="ascii.ecsv", overwrite=True)
+
+    with open(out_excl_file, "w") as pf:
+        yaml.dump(excl, pf, default_flow_style=False)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces two new commandline scripts.  They are given a `desimodel_*` prefix rather than `desi_*` to indicate that they are internal scripts not for general use.

The first script, `desi_extend_exclusions` is a cleaned up version of code that was previously kept in the data svn.  It works with the ConfigObj format files that define the positioner exclusion polygon and can be used to produce a new polygon that has an increased size.  Example:
```
desimodel_extend_exclusions \
--original ~/svn/desimodel_trunk/data/focalplane/exclusions_default.conf \
--increase 252
```
where the increase is integer microns.  This makes a new file and a plot.  The new file can then be fed into the `desi_generate_focalplane` script when making a new focalplane model.  The plot just draws a wire diagram of the input and output exclusion:
![exclusions_plus252 conf](https://user-images.githubusercontent.com/84221/94974942-faa2b380-04c4-11eb-9cdf-0ac55d226a5e.png)

The second script, `desimodel_restrict_positioners` takes an input focalplane model and produces a new one with each positioner's angle range restricted to ensure that the reach stays within the specified radius.  Example:
```
desimodel_restrict_positioners \
--reach 3.26 \
--in_date "2020-01-01T00:00:00" \
--out_date "2020-10-01T00:00:00"
```
This script attempts to formalize the process of taking a nominal focalplane model and making a new one with a restricted positioner reach.  It should be used instead of earlier ad-hoc scripts that might not be in version control.  For the example command above, sampling points on the input and output focalplanes and plotting the "unreachable" ones shows the effects of the restricted range.  The input unreachable targets:
![coverage_20000_full](https://user-images.githubusercontent.com/84221/94975098-6258fe80-04c5-11eb-96fc-406adb820315.png)
And the restricted range one:
![coverage_20000_restrict-3 26](https://user-images.githubusercontent.com/84221/94975109-700e8400-04c5-11eb-8f1b-c5a79f52d5ef.png)

