### PR TITLE
Add option to exclude petal locations from restricted reach

### DIFF
--- a/bin/desimodel_check_reach
+++ b/bin/desimodel_check_reach
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+"""Commandline script to check positioner reach.
+
+"""
+
+import sys
+import datetime
+import argparse
+
+import numpy as np
+
+from desimodel.io import load_focalplane
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--in_date",
+        type=str,
+        default=None,
+        required=False,
+        help="Input date in ISO format (e.g. '2020-01-01T00:00:00')."
+    )
+
+    args = parser.parse_args()
+
+    now_time = datetime.datetime.now()
+    now_time_str = None
+    try:
+        now_time_str = now_time.isoformat(timespec="seconds")
+    except TypeError:
+        # This must be python < 3.6, with no timespec option.
+        # Since the focalplane time is read from the file name without
+        # microseconds, the microseconds should be zero and so the
+        # default return string will be correct.
+        now_time_str = now_time.isoformat()
+
+    in_time = None
+    if args.in_date is None:
+        in_time = now_time
+    else:
+        in_time = datetime.datetime.strptime(args.in_date, "%Y-%m-%dT%H:%M:%S")
+
+    # Load the focalplane model
+
+    fp, excl, state, in_tmstr = load_focalplane(in_time)
+
+    # Compute the reach of each positioner.
+
+    nrows = len(fp)
+    for row in fp:
+        if row["DEVICE_TYPE"] != "POS":
+            # Skip non-positioner devices
+            continue
+        theta_arm = row["LENGTH_R1"]
+        phi_arm = row["LENGTH_R2"]
+
+        opening = np.radians(
+            180.0 - row["MIN_P"] - row["OFFSET_P"]
+        )
+        reach = np.sqrt(
+            theta_arm**2 + phi_arm**2 - 2.0 * theta_arm * phi_arm * np.cos(opening)
+        )
+        print(
+            "petal {}, location {:03d}, reach = {:0.3f} mm".format(
+                row["PETAL"], row["LOCATION"], reach
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/desimodel_restrict_positioners
+++ b/bin/desimodel_restrict_positioners
@@ -48,18 +48,43 @@ def main():
         help="The maximum positioner reach in millimeters."
     )
 
+    parser.add_argument(
+        "--exclude_petals",
+        type=str,
+        default=None,
+        required=False,
+        help="Comma-separated list of petal locations to exclude in restriction."
+    )
+
     args = parser.parse_args()
+
+    now_time = datetime.datetime.now()
+    now_time_str = None
+    try:
+        now_time_str = now_time.isoformat(timespec="seconds")
+    except TypeError:
+        # This must be python < 3.6, with no timespec option.
+        # Since the focalplane time is read from the file name without
+        # microseconds, the microseconds should be zero and so the
+        # default return string will be correct.
+        now_time_str = now_time.isoformat()
 
     in_time = None
     if args.in_date is None:
-        in_time = datetime.datetime.now()
+        in_time = now_time
     else:
         in_time = datetime.datetime.strptime(args.in_date, "%Y-%m-%dT%H:%M:%S")
 
     if args.out_date is None:
-        args.out_date = datetime.datetime.isoformat(
-            datetime.datetime.now()
-        )
+        args.out_date = now_time_str
+
+    petals = {x for x in range(10)}
+    if args.exclude_petals is not None:
+        expetals = [int(x) for x in args.exclude_petals.split(",")]
+        for p in expetals:
+            if p < 0 or p > 9:
+                raise RuntimeError("Petal locations to exclude must be in range 0-9")
+            petals.remove(p)
 
     # Load the starting focalplane model
 
@@ -70,6 +95,8 @@ def main():
 
     nrows = len(fp)
     for row in fp:
+        if row["PETAL"] not in petals:
+            continue
         theta_arm = row["LENGTH_R1"]
         phi_arm = row["LENGTH_R2"]
         if theta_arm <= 0 or phi_arm <= 0:


### PR DESCRIPTION
This PR adds a new option to `desimodel_restrict_positioners` to exclude some petals from the restricted reach.  A notebook comparing the results is [here](https://github.com/desihub/tutorials/blob/master/restrict_reach.ipynb).  The plots are included below.  Starting from the default pre-commissioning focalplane from a year ago, if we simulate a high density of fake target and plot the "unreachable" ones (see notebook linked above), then we get this:
![coverage_20000_unrestricted](https://user-images.githubusercontent.com/84221/105070575-5a06de00-5a38-11eb-95fe-b1015a10f57c.png)
If we look at the focalplane generated with:
```
desimodel_restrict_positioners \
    --in_date 2020-01-01T00:00:00 \
    --out_date 2020-03-06T00:00:00 \
    --reach 3.26
```
(i.e. the nominal commissioning focalplane), then we get:
![coverage_20000_allrestrict](https://user-images.githubusercontent.com/84221/105070860-bc5fde80-5a38-11eb-81b4-a5a1b6cf30ba.png)
If instead we exclude some petals from the restriction with:
```
desimodel_restrict_positioners \
    --in_date 2020-01-01T00:00:00 \
    --out_date 2021-01-19T00:00:00 \
    --reach 3.26 \
    --exclude_petals 0,4,8
```
Then we get:
![coverage_20000_excluded](https://user-images.githubusercontent.com/84221/105071080-fc26c600-5a38-11eb-82cd-8c7541073d5d.png)

This work is separate from synchronization with the online DB.