### PR TITLE
adding fastfiberacceptance originally in specsim

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desimodel Release Notes
 0.14.1 (unreleased)
 -------------------
 
-* No changes yet
+* Add fastfiberacceptance code originally in specsim.
 
 0.14.0 (2021-02-10)
 -------------------

--- a/py/desimodel/fastfiberacceptance.py
+++ b/py/desimodel/fastfiberacceptance.py
@@ -1,0 +1,146 @@
+import os
+import astropy.io.fits as pyfits
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+
+
+
+class FastFiberAcceptance(object):
+    """
+    This class reads an input fits file generated with specsim.fitgalsim
+    ($DESIMODEL/data/throughput/galsim-fiber-acceptance.fits)
+    and instanciates RegularGridInterpolator objects for 2D and 3D interpolation
+    of the pre-computed galsim fiber acceptance as a function of sigma (atmosphere+telescope blur, in um on focal surface), fiber offset from source (in um on focal surface), and half light radius (in arcsec) from extended source.
+    The average and rms interpolation function for POINT,DISK and BULGE profiles
+    are loaded.
+    """
+    def __init__(self,filename=None):
+
+        if filename is None :
+            if not "DESIMODEL" in os.environ :
+                print("need environment variable DESIMODEL or specify filename in constructor")
+                raise RuntimeError("need environment variable DESIMODEL or specify filename in constructor")
+            filename=os.path.join(os.environ["DESIMODEL"],"data/throughput/galsim-fiber-acceptance.fits")
+        hdulist=pyfits.open(filename)
+
+        sigma=hdulist["SIGMA"].data
+        offset=hdulist["OFFSET"].data
+        hlradius=hdulist["HLRAD"].data
+
+        self.fiber_acceptance_func = {}
+        self.fiber_acceptance_rms_func = {}
+        for source in ["POINT","DISK","BULGE"] :
+
+            data=hdulist[source].data
+            rms=hdulist[source[0]+"RMS"].data
+            dim=len(data.shape)
+            if dim == 2 :
+                self.fiber_acceptance_func[source] = RegularGridInterpolator(points=(sigma,offset),values=data,method="linear",bounds_error=False,fill_value=None)
+                self.fiber_acceptance_rms_func[source] = RegularGridInterpolator(points=(sigma,offset),values=rms,method="linear",bounds_error=False,fill_value=None)
+            elif dim == 3 :
+                self.fiber_acceptance_func[source] = RegularGridInterpolator(points=(hlradius,sigma,offset),values=data,method="linear",bounds_error=False,fill_value=None)
+                self.fiber_acceptance_rms_func[source] = RegularGridInterpolator(points=(hlradius,sigma,offset),values=rms,method="linear",bounds_error=False,fill_value=None)
+
+        hdulist.close()
+
+    def rms(self,source,sigmas,offsets=None,hlradii=None) :
+        """
+        returns fiber acceptance fraction rms for the given source,sigmas,offsets
+
+        Args:
+            source (string) : POINT, DISK or BULGE for point source, exponential profile or De Vaucouleurs profile
+            sigmas (np.array) : arbitrary shape, values of sigmas in um for the PSF due to atmosphere and telescope blur
+
+        Optional:
+            hlradii (np.array) : same shape as sigmas, half light radius in arcsec for source
+            offsets (np.array) : same shape as sigmas, values of offsets on focal surface between fiber and source, in um
+
+        Returns np.array with same shape as input
+        """
+        was_scalar = np.isscalar(sigmas)
+        sigmas = np.atleast_1d(sigmas)
+        original_shape = sigmas.shape
+
+        if offsets is None :
+            offsets=np.zeros(sigmas.shape)
+        else :
+            offsets=np.atleast_1d(offsets)
+            assert(sigmas.shape==offsets.shape)
+
+        if hlradii is not None :
+            hlradii=np.atleast_1d(hlradii)
+            assert(hlradii.shape==sigmas.shape)
+
+
+
+        res = None
+        if source == "POINT" :
+
+            res = self.fiber_acceptance_rms_func[source](np.array([sigmas.ravel(),offsets.ravel()]).T)
+
+        else :
+
+            if hlradii is None :
+                if source == "DISK" :
+                    hlradii = 0.45 * np.ones(sigmas.shape)
+                elif source == "BULGE" :
+                    hlradii = 1. * np.ones(sigmas.shape)
+            res = self.fiber_acceptance_rms_func[source](np.array([hlradii.ravel(),sigmas.ravel(),offsets.ravel()]).T)
+
+        res[res<0] = 0.
+        res[res>1] = 1.
+
+        if was_scalar :
+            return float(res[0])
+        return res.reshape(original_shape)
+
+    def value(self,source,sigmas,offsets=None,hlradii=None) :
+        """
+        returns the fiber acceptance for the given source,sigmas,offsets
+
+        Args:
+            source (string) : POINT, DISK or BULGE for point source, exponential profile or De Vaucouleurs profile
+            sigmas (np.array) : arbitrary shape, values of sigmas in um for the PSF due to atmosphere and telescope blur
+            offsets (np.array) : same shape as sigmas, values of offsets on focal surface between fiber and source, in um
+
+        Optional:
+            hlradii (np.array) : same shape as sigmas, half light radius in arcsec for source
+
+        Returns np.array with same shape as input
+        """
+
+        was_scalar = np.isscalar(sigmas)
+        sigmas = np.atleast_1d(sigmas)
+        original_shape = sigmas.shape
+
+        if offsets is None :
+            offsets=np.zeros(sigmas.shape)
+        else :
+            offsets=np.atleast_1d(offsets)
+            assert(sigmas.shape==offsets.shape)
+
+        if hlradii is not None :
+            hlradii=np.atleast_1d(hlradii)
+            assert(hlradii.shape==sigmas.shape)
+
+        res = None
+        if source == "POINT" :
+
+            res = self.fiber_acceptance_func[source](np.array([sigmas.ravel(),offsets.ravel()]).T)
+
+        else :
+
+            if hlradii is None :
+                if source == "DISK" :
+                    hlradii = 0.45 * np.ones(sigmas.shape)
+                elif source == "BULGE" :
+                    hlradii = 1. * np.ones(sigmas.shape)
+
+            res = self.fiber_acceptance_func[source](np.array([hlradii.ravel(),sigmas.ravel(),offsets.ravel()]).T)
+
+        res[res<0] = 0.
+        res[res>1] = 1.
+
+        if was_scalar :
+            return float(res[0])
+        return res.reshape(original_shape)

--- a/py/desimodel/test/test_fastfiberacceptance.py
+++ b/py/desimodel/test/test_fastfiberacceptance.py
@@ -1,0 +1,38 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""Test desimodel.fastfiberacceptance
+"""
+
+import unittest
+import numpy as np
+from desimodel.fastfiberacceptance import FastFiberAcceptance
+
+class TestFiberAcceptance(unittest.TestCase):
+    """Test FastFiberAcceptance
+    """
+
+    def test_fastfiberacceptance(self):
+        """Test interface options for tiles2pix"""
+
+        fa = FastFiberAcceptance()
+        platescale=70. #um/arsec
+        fwhm_arcsec_to_sigma_um = platescale/2.35
+
+        # only a test of type conversion
+        val = fa.value("POINT",sigmas=1.1*fwhm_arcsec_to_sigma_um)
+        assert(np.isscalar(val))
+        val = fa.value("POINT",sigmas=[1.1*fwhm_arcsec_to_sigma_um,1.4*fwhm_arcsec_to_sigma_um])
+        assert(val.size==2)
+        val = fa.value("POINT",sigmas=np.linspace(1.0,1.5,3)*fwhm_arcsec_to_sigma_um)
+        assert(val.size==3)
+        val = fa.value("POINT",sigmas=np.linspace(1.0,1.5,3)*fwhm_arcsec_to_sigma_um,offsets=np.zeros(3))
+        assert(val.size==3)
+
+def test_suite():
+    """Allows testing of only this module with the command::
+        python setup.py test -m <modulename>
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Moving fastfiberacceptance from specsim to desimodel in order to use this function in desispec for the flux calibration.