### PR TITLE
Use UTC time everywhere in the focalplane model.

### DIFF
--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -268,9 +268,9 @@ def create(
         )
 
     if startvalid is None:
-        startvalid = datetime.datetime.utcnow()
+        startvalid = datetime.datetime.now(tz=datetime.timezone.utc)
     else:
-        startvalid = datetime.datetime.strptime(startvalid, "%Y-%m-%dT%H:%M:%S")
+        startvalid = datetime.datetime.strptime(startvalid, "%Y-%m-%dT%H:%M:%S%z")
     file_date = startvalid.isoformat(timespec="seconds")
 
     if (petalloc is None) and (posdir is not None):

--- a/py/desimodel/inputs/focalplane_utils.py
+++ b/py/desimodel/inputs/focalplane_utils.py
@@ -741,7 +741,7 @@ def create_tables(n_fp_rows, n_state_rows=None):
         Column(
             name="TIME",
             length=n_state_rows,
-            dtype=np.dtype("a20"),
+            dtype=np.dtype("a30"),
             data=["UNKNOWN" for x in range(n_state_rows)],
             description="The timestamp of the event (UTC, ISO format)",
         ),


### PR DESCRIPTION
This work does a number of things:

- When creating a new focalplane model, Use UTC timezone datetime
  values everywhere in the file names and contents.

- When loading existing focalplane models, promote those times to
  UTC from naive time values.

- When syncing and appending to existing state logs in the old
  format, promote the table column to larger string size and
  the existing timestamps to UTC.

- desimodel.io.load_focalplane() now prints a warning if the
  requested time does not include a timezone.

- On the first call to load_focalplane(), all focalplane models
  were being loaded into memory.  Instead, the code now just
  caches the file names and date stamps on first call.  The data
  itself is loaded and cached only when actually needed.  This
  should improve performance as we have more and more focalplane
  models.