### PR TITLE
Move from yaml exclusion polygon format to json format.

### DIFF
--- a/bin/desi_update_focalplane_exclusion
+++ b/bin/desi_update_focalplane_exclusion
@@ -7,7 +7,8 @@ import argparse
 
 from datetime import datetime
 
-import yaml
+import json
+import gzip
 
 from desimodel.io import load_focalplane, datadir
 
@@ -54,11 +55,11 @@ def main():
     # Write out
 
     fpdir = os.path.join(datadir(), "focalplane")
-    excl_file = os.path.join(fpdir, "desi-exclusion_{}.yaml".format(tmstr))
+    excl_file = os.path.join(fpdir, "desi-exclusion_{}.json.gz".format(tmstr))
     tmp_excl = "{}.tmp".format(excl_file)
 
-    with open(tmp_excl, "w") as tf:
-        yaml.dump(exclude, tf, default_flow_style=False)
+    with gzip.open(tmp_excl, "wt", encoding="utf8") as tf:
+        json.dump(exclude, tf, indent=4)
 
     os.rename(tmp_excl, excl_file)
 

--- a/bin/desimodel_restrict_positioners
+++ b/bin/desimodel_restrict_positioners
@@ -14,7 +14,8 @@ import argparse
 import numpy as np
 import matplotlib.pyplot as plt
 
-import yaml
+import json
+import gzip
 
 from astropy.table import Table, Column
 
@@ -109,7 +110,7 @@ def main():
         )
 
     out_fp_file = "desi-focalplane_{}.ecsv".format(args.out_date)
-    out_excl_file = "desi-exclusion_{}.yaml".format(args.out_date)
+    out_excl_file = "desi-exclusion_{}.json.gz".format(args.out_date)
     out_state_file = "desi-state_{}.ecsv".format(args.out_date)
 
     fp.write(out_fp_file, format="ascii.ecsv", overwrite=True)
@@ -140,8 +141,8 @@ def main():
 
     out_state.write(out_state_file, format="ascii.ecsv", overwrite=True)
 
-    with open(out_excl_file, "w") as pf:
-        yaml.dump(excl, pf, default_flow_style=False)
+    with gzip.open(out_excl_file, "wt", encoding="utf8") as pf:
+        json.dump(excl, pf, indent=4)
 
 if __name__ == "__main__":
     main()

--- a/etc/desimodel_sync_kpno_cron.sh
+++ b/etc/desimodel_sync_kpno_cron.sh
@@ -59,7 +59,7 @@ echo "Found newest calibration file:  ${calpath}" >> "${logfile}"
 
 # Run it.
 failed="no"
-eval ${fpsync} --calib_file ${calpath} --commit 2>&1 >> "${logfile}"
+eval ${fpsync} --calib_file ${calpath} --commit >> "${logfile}" 2>&1
 if [ $? -ne 0 ]; then
     failed="yes"
     echo "Focalplane sync failed" >> "${logfile}"

--- a/etc/desimodel_sync_kpno_force.sh
+++ b/etc/desimodel_sync_kpno_force.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# IMPORTANT:  If you update this script, remember to copy it to
+# ~datasystems/desimodel_sync/ at KPNO.
+
+# Ensure that we are running this as the datasystems user
+if [ $(whoami) != "datasystems" ]; then
+    echo "You should only run this script at KPNO as the datasystems user"
+    exit 1
+fi
+
+# Path to the sync directory, containing the desimodel data trunk
+# checkout and logs.
+syncdir=/n/home/datasystems/desimodel_sync
+logdir="${syncdir}/logs"
+svntrunk="${syncdir}/desimodel_trunk"
+
+logdate="$(date -u --iso-8601=seconds)"
+logname="sync_${logdate}"
+logfile="${logdir}/${logname}"
+
+echo "Running at ${logdate}" > "${logfile}"
+
+# Get the latest desiconda install
+desiconda=$(ls -d /software/datasystems/desiconda/20* | sort | tail -n 1)
+
+# Get the latest stable version of desimodules
+desimodules=$(ls -d ${desiconda}/modulefiles/desimodules/2* | sort -V | tail -n 1 | xargs basename)
+
+echo "Using latest desiconda:  ${desiconda}" >> "${logfile}"
+echo "Using latest stable version of desimodules:  ${desimodules}" >> "${logfile}"
+
+# Set up environment
+
+export DESI_PRODUCT_ROOT="${desiconda}"
+export DESI_ROOT=/data/datasystems
+export DESI_TARGET=${DESI_ROOT}/target
+export DESI_SURVEYOPS=${DESI_ROOT}/survey/ops/surveyops/trunk
+
+module use ${DESI_PRODUCT_ROOT}/modulefiles
+module load desiconda
+module load desimodules/${desimodules}
+
+echo "Using desimodel data svn trunk at ${svntrunk}" >> "${logfile}"
+export DESIMODEL="${svntrunk}"
+
+# Find the sync script
+fpsync=$(which desi_sync_focalplane)
+echo "Using focalplane sync script:  ${fpsync}" >> "${logfile}"
+
+# Find the newest calibration file
+caldir="/data/focalplane/calibration/"
+calfile=$(ls ${caldir} | egrep '[0-9]{8}T[0-9]{6}.*' | sort | tail -n 1)
+calpath="${caldir}${calfile}"
+echo "Found newest calibration file:  ${calpath}" >> "${logfile}"
+
+# Run it.
+echo "Forcing creation of new focalplane model!" >> "${logfile}"
+
+failed="no"
+eval ${fpsync} --calib_file ${calpath} --commit --reset >> "${logfile}" 2>&1
+if [ $? -ne 0 ]; then
+    failed="yes"
+    echo "Focalplane creation failed" >> "${logfile}"
+fi
+
+# Send notifications.
+
+# Get our webhook address from the environment
+slack_web_hook=${DESI_SLACKBOT_DESIMODEL_SYNC}
+
+if [ "x${slack_web_hook}" = "x" ]; then
+    echo "Environment variable DESI_SLACKBOT_DESIMODEL_SYNC not set- skipping notifications" >> "${logfile}"
+else
+    # Create the JSON payload.
+    slackjson="${logfile}_slack.json"
+    headtail=15
+    echo -e "{\"text\":\"Focalplane DB sync (log at \`${logfile}\`):\n\`\`\`$(head -n ${headtail} ${logfile} | sed -e "s|'|\\\'|g")\`\`\`\n(Snip)\n\`\`\`$(tail -n ${headtail} ${logfile} | sed -e "s|'|\\\'|g")\`\`\`\"}" > "${slackjson}"
+    # Post it.
+    slackerror=$(curl -X POST -H 'Content-type: application/json' --data "$(cat ${slackjson})" ${slack_web_hook})
+    echo "Slack API post  ${slackerror}" >> "${logfile}"
+fi
+
+echo "Sync script finished at $(date -u --iso-8601=seconds)" >> "${logfile}"
+
+# Guard against accidental deletion
+chmod a-w "${logfile}"

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -319,6 +319,9 @@ def create(
         "OFFSET_P",
         "LENGTH_R1",
         "LENGTH_R2",
+    ]
+
+    st_cols = [
         "MIN_T",
         "MAX_T",
         "MIN_P",
@@ -355,6 +358,9 @@ def create(
                 for col in dev_cols:
                     if col in fp[petal][dev]:
                         out_fp[row][col] = fp[petal][dev][col]
+                for col in st_cols:
+                    if col in fp[petal][dev]:
+                        out_state[row][col] = fp[petal][dev][col]
             out_state[row]["LOCATION"] = out_fp[row]["LOCATION"]
             out_state[row]["STATE"] = valid_states["OK"]
             out_state[row]["EXCLUSION"] = "default"

--- a/py/desimodel/inputs/focalplane.py
+++ b/py/desimodel/inputs/focalplane.py
@@ -10,7 +10,8 @@ import os
 import datetime
 import re
 import csv
-import yaml
+import json
+import gzip
 import glob
 
 import configobj
@@ -466,7 +467,7 @@ def create(
     # that we don't need a single log for the entire survey.
 
     out_fp_file = os.path.join(outdir, "desi-focalplane_{}.ecsv".format(file_date))
-    out_excl_file = os.path.join(outdir, "desi-exclusion_{}.yaml".format(file_date))
+    out_excl_file = os.path.join(outdir, "desi-exclusion_{}.json.gz".format(file_date))
     out_state_file = os.path.join(outdir, "desi-state_{}.ecsv".format(file_date))
 
     out_fp.write(out_fp_file, format="ascii.ecsv", overwrite=True)
@@ -476,9 +477,9 @@ def create(
     del out_state
 
     # Now write out the exclusion polygons.  Since these are not tabular, we
-    # write to a YAML file.
+    # write to a JSON file.
 
-    with open(out_excl_file, "w") as pf:
-        yaml.dump(excl, pf, default_flow_style=False)
+    with gzip.open(out_excl_file, "wt", encoding='utf8') as pf:
+        json.dump(excl, pf, indent=4)
 
     return

--- a/py/desimodel/inputs/focalplane_sync.py
+++ b/py/desimodel/inputs/focalplane_sync.py
@@ -15,7 +15,7 @@ import subprocess as sp
 
 import ast
 
-import yaml
+import json
 
 import numpy as np
 
@@ -396,7 +396,7 @@ def create_from_calibs(
         log.info("Writing new focalplane model- ignoring previous ones...")
         out_fp_file = os.path.join(out_dir, "desi-focalplane_{}.ecsv".format(date_str))
         out_excl_file = os.path.join(
-            out_dir, "desi-exclusion_{}.yaml.gz".format(date_str)
+            out_dir, "desi-exclusion_{}.json.gz".format(date_str)
         )
         out_state_file = os.path.join(out_dir, "desi-state_{}.ecsv".format(date_str))
 
@@ -412,8 +412,8 @@ def create_from_calibs(
 
         state.write(out_state_file, format="ascii.ecsv", overwrite=True)
 
-        with gzip.open(out_excl_file, "wb") as pf:
-            yaml.dump(excl, stream=pf, encoding="utf-8", default_flow_style=False)
+        with gzip.open(out_excl_file, "wt", encoding="utf8") as pf:
+            json.dump(excl, pf, indent=4)
 
         if commit:
             cmesg = "Creating new focalplane model from DB sync {}".format(date_str)
@@ -486,7 +486,7 @@ def create_from_calibs(
                 newt[row] = nt.isoformat()
             st.replace_column("TIME", newt)
 
-        excl_file = os.path.join(out_dir, "desi-exclusion_{}.yaml.gz".format(oldtmstr))
+        excl_file = os.path.join(out_dir, "desi-exclusion_{}.json.gz".format(oldtmstr))
 
         tmp_state = "{}.tmp".format(state_file)
         prev_state = "{}.previous".format(state_file)
@@ -536,12 +536,11 @@ def create_from_calibs(
 
         # If we updated any exclusions, write a new file
         if n_new_excl > 0:
-            with gzip.open(tmp_excl, "wb") as pf:
-                yaml.dump(
+            with gzip.open(tmp_excl, "wt", encoding='utf8') as pf:
+                json.dump(
                     oldexcl,
-                    stream=pf,
-                    encoding="utf-8",
-                    default_flow_style=False
+                    pf,
+                    indent=4
                 )
             shutil.copy2(excl_file, prev_excl)
             os.rename(tmp_excl, excl_file)

--- a/py/desimodel/inputs/focalplane_sync.py
+++ b/py/desimodel/inputs/focalplane_sync.py
@@ -438,10 +438,9 @@ def create_from_calibs(
     else:
         # Load the current focalplane and just update the state
 
-        # Get the focalplane from one second before the current datestamp
+        # Get the focalplane from the current datestamp
         cur_date = datetime.datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S%z")
-        dtime = datetime.timedelta(seconds=1)
-        oldtime = cur_date - dtime
+        oldtime = cur_date
 
         oldfp, oldexcl, oldstate, oldtmstr = load_focalplane(oldtime)
 

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -527,7 +527,6 @@ def load_focalplane(time=None):
             loadroutine = json.load
         else:
             loadroutine = yaml.safe_load
-        print(focalplane_props['ex_file'])
         try:
             # First try to load uncompressed
             with open(focalplane_props["ex_file"], "r") as f:

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -427,7 +427,7 @@ def load_focalplane(time=None):
         fpdir = os.path.join(datadir(), "focalplane")
         fppat = re.compile(r"^desi-focalplane_(.*)\.ecsv$")
         stpat = re.compile(r"^desi-state_(.*)\.ecsv$")
-        expat = re.compile(r"^desi-exclusion_(.*)\.yaml.*$")
+        expat = re.compile(r"^desi-exclusion_(.*)\.(?:yaml|json).*$")
         fpraw = dict()
         msg = "Loading focalplanes from {}".format(fpdir)
         log.debug(msg)
@@ -521,14 +521,21 @@ def load_focalplane(time=None):
             focalplane_props["st_file"],
             format="ascii.ecsv"
         )
+        if (focalplane_props['ex_file'].endswith('.json') or
+            focalplane_props['ex_file'].endswith('.json.gz')):
+            import json
+            loadroutine = json.load
+        else:
+            loadroutine = yaml.safe_load
+        print(focalplane_props['ex_file'])
         try:
             # First try to load uncompressed
             with open(focalplane_props["ex_file"], "r") as f:
-                focalplane_props["ex_data"] = yaml.safe_load(f)
+                focalplane_props["ex_data"] = loadroutine(f)
         except:
             # Must be gzipped
             with gzip.open(focalplane_props["ex_file"], "rb") as f:
-                focalplane_props["ex_data"] = yaml.safe_load(f)
+                focalplane_props["ex_data"] = loadroutine(f)
 
     # Now "replay" the state up to our requested time.
     st_data = focalplane_props["st_data"]


### PR DESCRIPTION
This PR migrates from the existing yaml exclusion polygon format to json format.

Since we migrated from having only ~2 exclusions to ~2500 exclusion polygons, reading in the desi-exclusion.yaml file has become slow, taking ~10 s.  This is a significant fraction of the total time it takes to run fiberassign (~60 s; Dustin is looking at another ~30s in cross product evaluations).  It turns out that parsing YAML is just very slow.

The format is just a dictionary, so there's no reason not to put this in json, which it reads in 300x faster.

This PR then goes on to try to update all the different places that write desi-exclusion files to write out in json.

I was unable to test the focalplane.create(...) routine since it failed for unrelated reasons (XLRD library not supporting xlsx files?).  I was able to make sure that all other routines now produce json.gz exclusion files.

I have verified that json.load(...) produces values that agree exactly with yaml.load(...) values.  I have not verified that fiberassign runs produce identical targets, though I guess I should.

I have not checked a file into $DESIMODEL/data with the new json-ified outputs.  I don't know if I should replace the current file, or if we should do a new dump with the json output, or what.  And clearly any change there needs to be synced with an update to the desimodel code.