### PR TITLE
Update central DESIMODEL repo on sync

### DIFF
--- a/etc/desimodel_sync_kpno_cron.sh
+++ b/etc/desimodel_sync_kpno_cron.sh
@@ -65,6 +65,10 @@ if [ $? -ne 0 ]; then
     echo "Focalplane sync failed" >> "${logfile}"
 fi
 
+module swap desimodel/master
+echo "Updating $DESIMODEL/data." >> "${logfile}"
+svn up $DESIMODEL/data >> "${logfile}"
+
 # Send notifications.
 
 # Get our webhook address from the environment

--- a/etc/desimodel_sync_kpno_cron.sh
+++ b/etc/desimodel_sync_kpno_cron.sh
@@ -39,6 +39,7 @@ export DESI_PRODUCT_ROOT="${desiconda}"
 export DESI_ROOT=/data/datasystems
 export DESI_TARGET=${DESI_ROOT}/target
 export DESI_SURVEYOPS=${DESI_ROOT}/survey/ops/surveyops/trunk
+export DESIMODEL_CENTRAL_REPO=${DESI_ROOT}/survey/ops/desimodel/trunk
 
 module use ${DESI_PRODUCT_ROOT}/modulefiles
 module load desiconda
@@ -65,9 +66,8 @@ if [ $? -ne 0 ]; then
     echo "Focalplane sync failed" >> "${logfile}"
 fi
 
-module swap desimodel/master
-echo "Updating $DESIMODEL/data." >> "${logfile}"
-svn up $DESIMODEL/data >> "${logfile}"
+echo "Updating $DESIMODEL_CENTRAL_REPO." >> "${logfile}"
+svn up $DESIMODEL_CENTRAL_REPO >> "${logfile}"
 
 # Send notifications.
 

--- a/etc/desimodel_sync_kpno_force.sh
+++ b/etc/desimodel_sync_kpno_force.sh
@@ -64,6 +64,10 @@ if [ $? -ne 0 ]; then
     echo "Focalplane creation failed" >> "${logfile}"
 fi
 
+echo "Updating $DESIMODEL/data under desimodel/master." >> "${logfile}"
+module swap desimodel/master
+svn up $DESIMODEL/data >> "${logfile}"
+
 # Send notifications.
 
 # Get our webhook address from the environment

--- a/etc/desimodel_sync_kpno_force.sh
+++ b/etc/desimodel_sync_kpno_force.sh
@@ -36,6 +36,7 @@ export DESI_PRODUCT_ROOT="${desiconda}"
 export DESI_ROOT=/data/datasystems
 export DESI_TARGET=${DESI_ROOT}/target
 export DESI_SURVEYOPS=${DESI_ROOT}/survey/ops/surveyops/trunk
+export DESIMODEL_CENTRAL_REPO=${DESI_ROOT}/survey/ops/desimodel/trunk
 
 module use ${DESI_PRODUCT_ROOT}/modulefiles
 module load desiconda
@@ -64,9 +65,8 @@ if [ $? -ne 0 ]; then
     echo "Focalplane creation failed" >> "${logfile}"
 fi
 
-echo "Updating $DESIMODEL/data under desimodel/master." >> "${logfile}"
-module swap desimodel/master
-svn up $DESIMODEL/data >> "${logfile}"
+echo "Updating $DESIMODEL_CENTRAL_REPO." >> "${logfile}"
+svn up $DESIMODEL_CENTRAL_REPO >> "${logfile}"
 
 # Send notifications.
 


### PR DESCRIPTION
This PR adds a couple of lines to the focal plane sync scripts so that they also trigger an update to a new, central DESIMODEL repository.
/data/datasystems/survey/ops/desimodel/trunk