### PR TITLE
fix tiles2pix docstring and allow TILERA,TILEDEC

### DIFF
--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -242,6 +242,19 @@ class TestFootprint(unittest.TestCase):
         pix = footprint.tiles2pix(16, tiles=tiles, per_tile=False)
         self.assertEqual(set(pix), set(allpix))
 
+        #- also works with TILERA, TILEDEC
+        tiles.rename_column('RA', 'TILERA')
+        tiles.rename_column('DEC', 'TILEDEC')
+        pix2 = footprint.tiles2pix(16, tiles=tiles, per_tile=False)
+        self.assertTrue(np.all(pix == pix2))
+
+        #- also works with dict and numpy structured array
+        pix3 = footprint.tiles2pix(16, tiles=np.array(tiles), per_tile=False)
+        self.assertTrue(np.all(pix == pix3))
+        tdict = dict(RA=list(tiles['TILERA']), DEC=list(tiles['TILEDEC']))
+        pix4 = footprint.tiles2pix(16, tiles=tdict, per_tile=False)
+        self.assertTrue(np.all(pix == pix4))
+
     def test_tileids2pix(self):
         tiles = io.load_tiles()
         pix = footprint.tileids2pix(16, tiles['TILEID'][0:3])
@@ -340,6 +353,6 @@ class TestFootprint(unittest.TestCase):
 def test_suite():
     """Allows testing of only this module with the command::
 
-        python setup.py test -m <modulename>
+        python setup.py test -m desimodel.test.test_footprint
     """
     return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
This PR corrects the docstring for `desimodel.footprint.tiles2pix` (it takes a tiles table, not an array of tileids like tileids2pix).  It also adds support for TILERA, TILEDEC columns instead of RA, DEC, and adds support for dictionary-like input.  New tests confirm RA,DEC vs. TILERA,TILEDEC, and support for numpy structured arrays, astropy Tables, and dictionary inputs.

This would be convenient but not strictly necessary to use for Fuji healpix bookkeeping.  I'll self merge when needed if I don't get comments.

Note: the desimodel tiles file is deprecated and very out of date; I didn't try to remove that in this PR so that I don't accidentally break something else, but the intended usage here is to pass in a new tiles table, e.g. the tiles that are included in a production run, or one of the tiles tables in svn surveyops/ops .