### PR TITLE
endian fix for scipy 1.10

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,10 +10,13 @@ desimodel Release Notes
   (PR `#159`_).
 * Fix :func:`~desimodel.footprint.tiles2pix` to allow ``TILERA``, ``TILEDEC``
   (PR `#156`_).
+* fastfiberacceptance use ``.astype('=f8')`` to force native endianness
+  for scipy>=1.10.0 compatibility (PR `#164`_).
 
 .. _`#156`: https://github.com/desihub/desimodel/pull/156
 .. _`#159`: https://github.com/desihub/desimodel/pull/159
 .. _`#163`: https://github.com/desihub/desimodel/pull/163
+.. _`#164`: https://github.com/desihub/desimodel/pull/164
 
 0.17.0 (2021-09-19)
 -------------------

--- a/py/desimodel/fastfiberacceptance.py
+++ b/py/desimodel/fastfiberacceptance.py
@@ -24,9 +24,9 @@ class FastFiberAcceptance(object):
             filename=os.path.join(os.environ["DESIMODEL"],"data/throughput/galsim-fiber-acceptance.fits")
         hdulist=pyfits.open(filename)
 
-        sigma=hdulist["SIGMA"].data
-        offset=hdulist["OFFSET"].data
-        hlradius=hdulist["HLRAD"].data
+        sigma=hdulist["SIGMA"].data.astype('=f8')
+        offset=hdulist["OFFSET"].data.astype('=f8')
+        hlradius=hdulist["HLRAD"].data.astype('=f8')
 
         self._sigma=sigma
         self._offset=offset
@@ -40,8 +40,8 @@ class FastFiberAcceptance(object):
         self.psf_seeing_func = {}
 
         for source in ["POINT","DISK","BULGE"] :
-            data=hdulist[source].data
-            rms=hdulist[source[0]+"RMS"].data
+            data=hdulist[source].data.astype('=f8')
+            rms=hdulist[source[0]+"RMS"].data.astype('=f8')
             dim=len(data.shape)
 
             self._data[source] = data

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if os.path.isdir('bin'):
 setup_keywords['provides'] = [setup_keywords['name']]
 setup_keywords['python_requires'] = '>=3.5'
 setup_keywords['zip_safe'] = False
-setup_keywords['use_2to3'] = False
+# setup_keywords['use_2to3'] = False
 setup_keywords['packages'] = find_packages('py')
 setup_keywords['package_dir'] = {'': 'py'}
 setup_keywords['cmdclass'] = {'module_file': ds.DesiModule,


### PR DESCRIPTION
This PR fixes an incompatibility with scipy 1.10 released on January 3 2023 (yesterday).  See [desispec PR #1954 tests](https://github.com/desihub/desispec/actions/runs/3841673383/jobs/6542162594) for example failures:
```
py/desispec/fluxcalibration.py:957: in compute_flux_calibration
    point_source_correction = flat_to_psf_flux_correction(frame.fibermap,exposure_seeing_fwhm)
py/desispec/fiberfluxcorr.py:65: in flat_to_psf_flux_correction
    fiber_frac = fa.value("POINT",sigmas_um,offsets_um)
/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/desimodel/fastfiberacceptance.py:155: in value
    res = self.fiber_acceptance_func[source](np.array([sigmas.ravel(),offsets.ravel()]).T)
/opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/scipy/interpolate/_rgi.py:336: in __call__
    result = evaluate_linear_2d(self.values,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   ValueError: Big-endian buffer not supported on little-endian compiler

_rgi_cython.pyx:19: ValueError
```

desimodel tests also fail with scipy/1.10 (I checked with a custom conda environment), but we hadn't opened a desimodel PR to trigger those today so we first tripped on it with desispec tests.

The underlying problem is that the FastFiberAcceptance RegularGridInterpolator was being created with big-endian data from a FITS file, but scipy+cython no longer support that.  The fix is to force all data to native endianness (`.astype('=f8')`) upon loading.

This PR fixes the desimodel tests and that particular failing test of desispec.  We may have other endianness issues to fix on the desispec side, but at minimum we need this on the desimodel side.

FYI @akremin @araichoor @marcelo-alvarez @dkirkby @julienguy @weaverba137 