### PR TITLE
Update KPNO sync scripts to use the default software stack

### DIFF
--- a/etc/desimodel_sync_kpno_cron.sh
+++ b/etc/desimodel_sync_kpno_cron.sh
@@ -24,13 +24,13 @@ logfile="${logdir}/${logname}"
 
 echo "Running at ${logdate}" > "${logfile}"
 
-# Get the latest desiconda install
-desiconda=$(ls -d /software/datasystems/desiconda/20* | sort | tail -n 1)
+# Use the latest default desiconda version
+desiconda=/software/datasystems/desiconda/default
 
 # Get the latest stable version of desimodules
 desimodules=$(ls -d ${desiconda}/modulefiles/desimodules/2* | sort -V | tail -n 1 | xargs basename)
 
-echo "Using latest desiconda:  ${desiconda}" >> "${logfile}"
+echo "Using default desiconda:  ${desiconda}" >> "${logfile}"
 echo "Using latest stable version of desimodules:  ${desimodules}" >> "${logfile}"
 
 # Set up environment
@@ -44,6 +44,7 @@ export DESIMODEL_CENTRAL_REPO=${DESI_ROOT}/survey/ops/desimodel/trunk
 module use ${DESI_PRODUCT_ROOT}/modulefiles
 module load desiconda
 module load desimodules/${desimodules}
+module swap desimodel/0.17.0
 
 echo "Using desimodel data svn trunk at ${svntrunk}" >> "${logfile}"
 export DESIMODEL="${svntrunk}"

--- a/etc/desimodel_sync_kpno_cron.sh
+++ b/etc/desimodel_sync_kpno_cron.sh
@@ -59,6 +59,11 @@ calfile=$(ls ${caldir} | egrep '[0-9]{8}T[0-9]{6}.*' | sort | tail -n 1)
 calpath="${caldir}${calfile}"
 echo "Found newest calibration file:  ${calpath}" >> "${logfile}"
 
+# Make sure that any locally modified files are removed
+echo "Ensuring clean svn tree at ${DESIMODEL}" >> "${logfile}"
+svn revert -R "${svntrunk}/data" >> "${logfile}"
+svn up "${svntrunk}/data" >> "${logfile}"
+
 # Run it.
 failed="no"
 eval ${fpsync} --calib_file ${calpath} --commit >> "${logfile}" 2>&1

--- a/etc/desimodel_sync_kpno_force.sh
+++ b/etc/desimodel_sync_kpno_force.sh
@@ -64,15 +64,14 @@ svn up "${svntrunk}/data" >> "${logfile}"
 # Run it.
 echo "Forcing creation of new focalplane model!" >> "${logfile}"
 
-failed="no"
 eval ${fpsync} --calib_file ${calpath} --commit --reset >> "${logfile}" 2>&1
 if [ $? -ne 0 ]; then
-    failed="yes"
     echo "Focalplane creation failed" >> "${logfile}"
+else
+    echo "Focalplane sync completed" >> "${logfile}"
+    echo "Updating $DESIMODEL_CENTRAL_REPO." >> "${logfile}"
+    svn up $DESIMODEL_CENTRAL_REPO >> "${logfile}"
 fi
-
-echo "Updating $DESIMODEL_CENTRAL_REPO." >> "${logfile}"
-svn up $DESIMODEL_CENTRAL_REPO >> "${logfile}"
 
 # Send notifications.
 

--- a/etc/desimodel_sync_kpno_force.sh
+++ b/etc/desimodel_sync_kpno_force.sh
@@ -56,6 +56,11 @@ calfile=$(ls ${caldir} | egrep '[0-9]{8}T[0-9]{6}.*' | sort | tail -n 1)
 calpath="${caldir}${calfile}"
 echo "Found newest calibration file:  ${calpath}" >> "${logfile}"
 
+# Make sure that any locally modified files are removed
+echo "Ensuring clean svn tree at ${DESIMODEL}" >> "${logfile}"
+svn revert -R "${svntrunk}/data" >> "${logfile}"
+svn up "${svntrunk}/data" >> "${logfile}"
+
 # Run it.
 echo "Forcing creation of new focalplane model!" >> "${logfile}"
 

--- a/etc/desimodel_sync_kpno_force.sh
+++ b/etc/desimodel_sync_kpno_force.sh
@@ -21,13 +21,13 @@ logfile="${logdir}/${logname}"
 
 echo "Running at ${logdate}" > "${logfile}"
 
-# Get the latest desiconda install
-desiconda=$(ls -d /software/datasystems/desiconda/20* | sort | tail -n 1)
+# Use the latest default desiconda version
+desiconda=/software/datasystems/desiconda/default
 
 # Get the latest stable version of desimodules
 desimodules=$(ls -d ${desiconda}/modulefiles/desimodules/2* | sort -V | tail -n 1 | xargs basename)
 
-echo "Using latest desiconda:  ${desiconda}" >> "${logfile}"
+echo "Using default desiconda:  ${desiconda}" >> "${logfile}"
 echo "Using latest stable version of desimodules:  ${desimodules}" >> "${logfile}"
 
 # Set up environment
@@ -41,6 +41,7 @@ export DESIMODEL_CENTRAL_REPO=${DESI_ROOT}/survey/ops/desimodel/trunk
 module use ${DESI_PRODUCT_ROOT}/modulefiles
 module load desiconda
 module load desimodules/${desimodules}
+module swap desimodel/0.17.0
 
 echo "Using desimodel data svn trunk at ${svntrunk}" >> "${logfile}"
 export DESIMODEL="${svntrunk}"


### PR DESCRIPTION
This changes the focalplane sync scripts to use the new `default` symlink to get the software stack to load.