### PR TITLE
Update default tiles file path in io.loadtiles()

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -85,8 +85,10 @@ jobs:
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 python -m pip install pyyaml requests scipy healpy matplotlib
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
+                # ADM grab the surveyops directory.
+                wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/
             - name: Run the test with coverage
-              run: DESIMODEL=$(pwd) pytest --cov
+              run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest --cov
             - name: Coveralls
               env:
                 COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,8 +45,10 @@ jobs:
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 python -m pip install pyyaml requests scipy healpy matplotlib
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
+                # ADM grab the surveyops directory.
+                wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/
             - name: Run the test
-              run: DESIMODEL=$(pwd) pytest
+              run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest
 
     coverage:
         name: Test coverage

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,9 +6,11 @@ desimodel Release Notes
 -------------------
 
 * Change default file for :func:`~desimodel.io.loadtiles` [`PR #168`_]:
-  * Now reads from :envvar:`SURVEYOPS` ``(/trunk/ops/tiles-main.ecsv)``
+  * Now reads from :envvar:`DESI_SURVEYOPS` ``(/trunk/ops/tiles-main.ecsv)``
   * Also adds option to limit tiles to specified ``PROGRAM`` names.
   * Will now automatically load both `.fits` and `.ecsv` files.
+  * Maintains option to read from old :envvar:`DESIMODEL` location.
+  * Tests cover both :envvar:`DESI_SURVEYOPS` and :envvar:`DESIMODEL` cases.
   * Addresses `issue #167`_.
 
 .. _`#168`: https://github.com/desihub/desimodel/pull/168

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desimodel Release Notes
 0.18.1 (unreleased)
 -------------------
 
-* Change default file for :func:`~desimodel.io.loadtiles` [`PR #168`_]:
+* Change default file for :func:`~desimodel.io.loadtiles` (PR `#168`_):
   * Now reads from :envvar:`DESI_SURVEYOPS` ``(/trunk/ops/tiles-main.ecsv)``
   * Also adds option to limit tiles to specified ``PROGRAM`` names.
   * Will now automatically load both `.fits` and `.ecsv` files.
@@ -13,6 +13,7 @@ desimodel Release Notes
   * Tests cover both :envvar:`DESI_SURVEYOPS` and :envvar:`DESIMODEL` cases.
   * Addresses `issue #167`_.
 
+.. _`issue #167`: https://github.com/desihub/desimodel/issues/167
 .. _`#168`: https://github.com/desihub/desimodel/pull/168
 
 0.18.0 (2023-01-05)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ desimodel Release Notes
 -------------------
 
 * Change default file for :func:`~desimodel.io.loadtiles` (PR `#168`_):
+
   * Now reads from :envvar:`DESI_SURVEYOPS` ``(/trunk/ops/tiles-main.ecsv)``
   * Also adds option to limit tiles to specified ``PROGRAM`` names.
   * Will now automatically load both `.fits` and `.ecsv` files.
@@ -258,11 +259,13 @@ Data changes to svn, no code changes:
 ------------------
 
 * Update data and associated code to reflect changes in DESI-347-v13 (PR `#89`_):
+
   * ``data/throughput/thru-[brz].fits``: new corrector coatings.
   * ``data/throughput/DESI-0347_blur.ecsv``: new achromatic blurs.
   * ``data/desi.yaml``: new read noise and dark currents.
   * ``data/focalplane/gfa.ecsv``: replace ``RADIUS_MM`` with ``S``.
   * ``data/throughput/DESI-0347_static_[123].fits``: replace random offset files (RMS=10.886um) with static offset files (RMS=8.0um).
+
 * Use a new svn branch test-0.9.6 for travis tests (was test-0.9.3).
 
 .. _`#89`: https://github.com/desihub/desimodel/pull/89

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,13 @@ desimodel Release Notes
 0.18.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Change default file for :func:`~desimodel.io.loadtiles` [`PR #168`_]:
+  * Now reads from :envvar:`SURVEYOPS` ``(/trunk/ops/tiles-main.ecsv)``
+  * Also adds option to limit tiles to specified ``PROGRAM`` names.
+  * Will now automatically load both `.fits` and `.ecsv` files.
+  * Addresses `issue #167`_.
+
+.. _`#168`: https://github.com/desihub/desimodel/pull/168
 
 0.18.0 (2023-01-05)
 -------------------

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -22,18 +22,26 @@ log = get_logger()
 _pass2program = None
 
 
-def pass2program(tilepass):
+def pass2program(tilepass, surveyops=False):
     '''Converts integer tile pass number to string program name.
 
     Args:
         tilepass (int or int array): tiling pass number.
+    surveyops (bool): ``True`` to look for tiles in $DESI_SURVEYPOPS.
 
     Returns:
         Program name for each pass (str or list of str).
     '''
     global _pass2program
+    # ADM this function isn't useful if looking in the DESI_SURVEYOPS
+    # ADM directory as the real data is not ordered by pass.
+    if surveyops == True:
+        msg = "Function is not meaningful when looking in the DESI_SURVEYOPS "
+        msg += "directory as the real, Main Survey, data is not ordered by pass"
+        log.critical(msg)
+        raise ValueError(msg)
     if _pass2program is None:
-        tiles = load_tiles()
+        tiles = load_tiles(surveyops=False)
         _pass2program = dict(set(zip(tiles['PASS'], tiles['PROGRAM'])))
     if np.isscalar(tilepass):
         return _pass2program[tilepass]

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -337,10 +337,11 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
         subset &= ~np.char.startswith(tiledata["PROGRAM"], "EXTRA")
 
     # ADM filter to program names if requested.
-    # ADM guard against a string being passed.
-    programs = np.atleast_1d(programs)
-    for program in programs:
-        subset &= tiledata["PROGRAM"] == program
+    if programs is not None:
+        # ADM guard against a single string being passed.
+        programs = np.atleast_1d(programs)
+        for program in programs:
+            subset &= tiledata["PROGRAM"] == program
 
     if np.all(subset):
         return tiledata

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -24,6 +24,7 @@ log = get_logger()
 
 _thru = dict()
 
+
 # ADM raise a custom exception when an environment variable is missing.
 class MissingEnvVar(Exception):
     pass
@@ -218,7 +219,8 @@ def load_fiberpos():
 _tiles = dict()
 
 
-def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=None):
+def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True,
+               programs=None, surveyops=True):
     """Return DESI tiles structure from ``$DESI_SURVEYOPS/trunk/ops/tiles-main.ecsv``.
 
     Parameters
@@ -236,6 +238,9 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
     programs : :class:`list` or `str`, optional
         Pass a list of program names to restrict to only those programs,
         e.g. ["DARK", "BACKUP"].
+    surveyops : :class:`bool`
+        If ``True`` then find the relevant path for the $DESI_SURVEYOPS
+        directory rather than the $DESIMODEL directory.
 
     Returns
     -------
@@ -263,8 +268,8 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
        $DESI_SURVEYOPS/ops are always both checked, to cover different
        svn checkout approaches.
     1. If the value includes an explicit path, even ``./``, use that file.
-    2. If the value does *not* include an explicit path, *and* the file 
-       name is identical to a file in ``$DESI_SURVEYOPS/trunk/ops/``, use 
+    2. If the value does *not* include an explicit path, *and* the file
+       name is identical to a file in ``$DESI_SURVEYOPS/trunk/ops/``, use
        the file in ``$DESI_SURVEYOPS/trunk/ops/`` and issue a warning.
     3. If no matching file can be found at all, raise an exception.
     """
@@ -272,13 +277,16 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
 
     if tilesfile is None:
         # Use the default
-        tilesfile = findfile("tiles-main.ecsv", surveyops=True)
+        if surveyops:
+            tilesfile = findfile("tiles-main.ecsv", surveyops=surveyops)
+        else:
+            tilesfile = findfile("footprint/desi-tiles.fits", surveyops=surveyops)
     else:
         # If full path isn't included, check local vs $DESI_SURVEYOPS/ops
         tilepath, filename = os.path.split(tilesfile)
         if tilepath == "":
             have_local = os.path.isfile(tilesfile)
-            checkfile = findfile(tilesfile, surveyops=True)
+            checkfile = findfile(tilesfile, surveyops=surveyops)
             have_dmdata = os.path.isfile(checkfile)
             if have_dmdata:
                 if have_local:

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -214,7 +214,7 @@ def load_fiberpos():
 _tiles = dict()
 
 
-def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True):
+def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=None):
     """Return DESI tiles structure from ``$SURVEYOPS/trunk/ops/tiles-main.ecsv``.
 
     Parameters
@@ -229,6 +229,9 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True):
     cache : :class:`bool`, optional
         If ``False``, force reload of data from tiles file, instead of
         using cached values.
+    programs : :class:`list` or `str`, optional
+        Pass a list of program names to restrict to only those programs,
+        e.g. ["DARK", "BACKUP"].
 
     Returns
     -------
@@ -332,6 +335,12 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True):
     # - Filter out PROGRAM=EXTRA tiles if requested
     if not extra:
         subset &= ~np.char.startswith(tiledata["PROGRAM"], "EXTRA")
+
+    # ADM filter to program names if requested.
+    # ADM guard against a string being passed.
+    programs = np.atleast_1d(programs)
+    for program in programs:
+        subset &= tiledata["PROGRAM"] == program
 
     if np.all(subset):
         return tiledata

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -273,7 +273,7 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
         tilepath, filename = os.path.split(tilesfile)
         if tilepath == "":
             have_local = os.path.isfile(tilesfile)
-            checkfile = findfile(os.path.join(tilesfile))
+            checkfile = findfile(tilesfile, surveyops=True)
             have_dmdata = os.path.isfile(checkfile)
             if have_dmdata:
                 if have_local:
@@ -299,12 +299,12 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
 
     # ADM allow reading from either .fits or .ecsv files.
     # ADM guard against the possibility that the file is zipped.
-    fits = ".fits" in os.path.basename(tilesfile)
+    isfits = ".fits" in os.path.basename(tilesfile)
 
     if cache and tilesfile in _tiles:
         tiledata = _tiles[tilesfile]
     else:
-        if fits:
+        if isfits:
             with fits.open(tilesfile, memmap=False) as hdulist:
                 tiledata = hdulist[1].data
             #

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -706,7 +706,10 @@ def datadir(surveyops=False):
         If ``True`` then find the relevant path for the $DESI_SURVEYOPS
         directory rather than the $DESIMODEL directory.
 
-    If set, :envvar:`DESIMODEL` overrides data installed with the package.
+    Notes
+    -----
+    If `surveyops`==``False`` and :envvar:`DESIMODEL` is set, then
+    $DESIMODEL overrides data installed with the package.
     """
     if surveyops:
         if "DESI_SURVEYOPS" in os.environ:

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -267,9 +267,9 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
 
     if tilesfile is None:
         # Use the default
-        tilesfile = findfile("tiles-main.ecsv")
+        tilesfile = findfile("tiles-main.ecsv", surveyops=True)
     else:
-        # If full path isn't included, check local vs $DESIMODEL/data/footprint
+        # If full path isn't included, check local vs $SURVEYOPS/ops
         tilepath, filename = os.path.split(tilesfile)
         if tilepath == "":
             have_local = os.path.isfile(tilesfile)
@@ -279,7 +279,7 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
                 if have_local:
                     msg = (
                         "$SURVEYOPS/(trunk)/ops/{0} is shadowed by a local"
-                        + " file. Choosing $DESIMODEL file."
+                        + " file. Choosing $SURVEYOPS file."
                         + ' Use tilesfile="./{0}" if you want the local copy'
                         + " instead."
                     ).format(tilesfile)
@@ -299,8 +299,7 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
 
     # ADM allow reading from either .fits or .ecsv files.
     # ADM guard against the possibility that the file is zipped.
-    if ".fits" in os.path.basename(tilesfile):
-        fits = True
+    fits = ".fits" in os.path.basename(tilesfile)
 
     if cache and tilesfile in _tiles:
         tiledata = _tiles[tilesfile]
@@ -340,8 +339,10 @@ def load_tiles(onlydesi=True, extra=False, tilesfile=None, cache=True, programs=
     if programs is not None:
         # ADM guard against a single string being passed.
         programs = np.atleast_1d(programs)
+        isprog = np.zeros(len(tiledata), dtype=bool)
         for program in programs:
-            subset &= tiledata["PROGRAM"] == program
+            isprog |= tiledata["PROGRAM"] == program
+        subset &= isprog
 
     if np.all(subset):
         return tiledata

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -51,18 +51,22 @@ class TestFootprint(unittest.TestCase):
         with self.assertRaises(KeyError):
             footprint.pass2program(999)
 
+
     def test_program2pass(self):
         '''Test footprint.program2pass().
         '''
-        self.assertEqual(len(footprint.program2pass('DARK')), 4)
-        self.assertEqual(len(footprint.program2pass('GRAY')), 1)
-        self.assertEqual(len(footprint.program2pass('BRIGHT')), 3)
+        self.assertEqual(len(footprint.program2pass('DARK')), 7)
+        # ADM in the real survey data there is no GRAY program...
+#        self.assertEqual(len(footprint.program2pass('GRAY')), 1)
+        # ADM ...but there is a BACKUP program.
+        self.assertEqual(len(footprint.program2pass('BACKUP')), 1)
+        self.assertEqual(len(footprint.program2pass('BRIGHT')), 4)
 
-        passes = footprint.program2pass(['DARK', 'GRAY', 'BRIGHT'])
+        passes = footprint.program2pass(['DARK', 'BACKUP', 'BRIGHT'])
         self.assertEqual(len(passes), 3)
-        self.assertEqual(len(passes[0]), 4)
+        self.assertEqual(len(passes[0]), 7)
         self.assertEqual(len(passes[1]), 1)
-        self.assertEqual(len(passes[2]), 3)
+        self.assertEqual(len(passes[2]), 4)
 
         with self.assertRaises(ValueError):
             footprint.program2pass('BLAT')

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -174,8 +174,47 @@ class TestIO(unittest.TestCase):
         self.assertEqual(npix,12*nside*nside)
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
+    def test_load_tiles_old(self):
+        """Test loading of tile files for old default DESIMODEL case.
+        """
+        # starting clean
+        self.assertEqual(io._tiles, {})
+        t0 = io.load_tiles(cache=False, surveyops=False)
+        self.assertEqual(len(io._tiles), 0)
+        # loading tiles fills the cache with one items
+        t1 = io.load_tiles(onlydesi=False, surveyops=False)
+        self.assertEqual(len(io._tiles), 1)
+        tile_cache_id1 = id(list(io._tiles.values())[0])
+        # reloading, even with a filter, shouldn't change cache
+        t2 = io.load_tiles(onlydesi=True, surveyops=False)
+        self.assertEqual(len(io._tiles), 1)
+        tile_cache_id2 = id(list(io._tiles.values())[0])
+        self.assertEqual(tile_cache_id1, tile_cache_id2)
+        #- Temporarily support OBSCONDITIONS as u2 (old) or i4 (new)
+        self.assertTrue(np.issubdtype(t1['OBSCONDITIONS'].dtype, np.signedinteger) or
+                        np.issubdtype(t1['OBSCONDITIONS'].dtype, np.unsignedinteger) )
+        self.assertTrue(np.issubdtype(t2['OBSCONDITIONS'].dtype, np.signedinteger) or
+                        np.issubdtype(t2['OBSCONDITIONS'].dtype, np.unsignedinteger) )
+        self.assertLess(len(t2), len(t1))
+        # All tiles in DESI are also in full set.
+        self.assertTrue(np.all(np.in1d(t2['TILEID'], t1['TILEID'])))
+        # I think this is the exact same test as above, except using set theory.
+        self.assertEqual(len(set(t2.TILEID) - set(t1.TILEID)), 0)
+        t3 = io.load_tiles(onlydesi=False, surveyops=False)
+        tile_cache_id3 = id(list(io._tiles.values())[0])
+        self.assertEqual(tile_cache_id1, tile_cache_id3)
+        self.assertTrue(np.issubdtype(t3['OBSCONDITIONS'].dtype, np.signedinteger) or
+                        np.issubdtype(t3['OBSCONDITIONS'].dtype, np.unsignedinteger) )
+        # Check for extra tiles.
+        a = io.load_tiles(extra=False, surveyops=False)
+        self.assertEqual(np.sum(np.char.startswith(a['PROGRAM'], 'EXTRA')), 0)
+        b = io.load_tiles(extra=True, surveyops=False)
+        self.assertGreater(np.sum(np.char.startswith(b['PROGRAM'], 'EXTRA')), 0)
+        self.assertLess(len(a), len(b))
+
+    @unittest.skipUnless(surveyops_available, surveyops_message)
     def test_load_tiles(self):
-        """Test loading of tile files.
+        """Test loading of tile files for default DESI_SURVEYOPS case.
         """
         # starting clean
         self.assertEqual(io._tiles, {})
@@ -190,27 +229,12 @@ class TestIO(unittest.TestCase):
         self.assertEqual(len(io._tiles), 1)
         tile_cache_id2 = id(list(io._tiles.values())[0])
         self.assertEqual(tile_cache_id1, tile_cache_id2)
-        #- Temporarily support OBSCONDITIONS as u2 (old) or i4 (new)
-        self.assertTrue(np.issubdtype(t1['OBSCONDITIONS'].dtype, np.signedinteger) or
-                        np.issubdtype(t1['OBSCONDITIONS'].dtype, np.unsignedinteger) )
-        self.assertTrue(np.issubdtype(t2['OBSCONDITIONS'].dtype, np.signedinteger) or
-                        np.issubdtype(t2['OBSCONDITIONS'].dtype, np.unsignedinteger) )
         self.assertLess(len(t2), len(t1))
         # All tiles in DESI are also in full set.
         self.assertTrue(np.all(np.in1d(t2['TILEID'], t1['TILEID'])))
-        # I think this is the exact same test as above, except using set theory.
-        self.assertEqual(len(set(t2.TILEID) - set(t1.TILEID)), 0)
         t3 = io.load_tiles(onlydesi=False)
         tile_cache_id3 = id(list(io._tiles.values())[0])
         self.assertEqual(tile_cache_id1, tile_cache_id3)
-        self.assertTrue(np.issubdtype(t3['OBSCONDITIONS'].dtype, np.signedinteger) or
-                        np.issubdtype(t3['OBSCONDITIONS'].dtype, np.unsignedinteger) )
-        # Check for extra tiles.
-        a = io.load_tiles(extra=False)
-        self.assertEqual(np.sum(np.char.startswith(a['PROGRAM'], 'EXTRA')), 0)
-        b = io.load_tiles(extra=True)
-        self.assertGreater(np.sum(np.char.startswith(b['PROGRAM'], 'EXTRA')), 0)
-        self.assertLess(len(a), len(b))
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_load_tiles_alt(self):

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -240,7 +240,7 @@ class TestIO(unittest.TestCase):
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_load_tiles_alt_old(self):
-        """Test alternative tile-load for old default DATAMODEL case
+        """Test alternative tile-load for old default DESIMODEL case
         """
         # starting clean
         self.assertEqual(io._tiles, {})


### PR DESCRIPTION
This PR would address #167 by changing the default path name for loading the tiles file to the `SURVEYOPS` directory, specifically to `SURVEYOPS/trunk/ops/tiles-main.ecsv`. It also:

- Updates `io.loadtiles()` to automatically read `.ecsv` files as well as `.fits` files.
- Adds an option to limit the loaded tiles to a specific list of `PROGRAM` names.

I'm pinging @sbailey for a review as I'm belatedly worried that there's no way to update the default tiles file (as requested in #167) while retaining backward compatibility. 

Stephen should let me know if he'd prefer an alternate solution to breaking backward compatibility, such as adding a new kwarg, e.g. `surveyops=False`, to `io.loadtiles()` and then widely requesting the users identified by @ashleyjross to sprinkle `surveyops=True` throughout their code.