### PR TITLE
Optionally fetch the valid date range from load_focalplane().

### DIFF
--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -460,18 +460,22 @@ def ensure_focalplane_loaded():
         ))
 
 def get_focalplane_dates():
-    ''' Returns the dates of new focalplane definitions.
+    """Returns the dates of new focalplane definitions.
 
     There are two levels of time-dependent changes within the focalplane.  First are the
     focalplane definitions, defined by a set of files
-       desimodel-data/data/focalplane/{desi-exclusion,desi-focalplane,desi-state}_DATE.*
+    ``$DESIMODEL/data/focalplane/{desi-exclusion,desi-focalplane,desi-state}_DATE.``.
     Those are the dates returned by this function, as a list of datetime objects.
 
     The second level is that, within the "state" table, there are changes to the states of
-    individual positioners.  (These are the dates returned when `get_time_range=True` is set
-    in load_focalplane.)
+    individual positioners.  (These are the dates returned when ``get_time_range=True`` is set
+    in ``load_focalplane()``.)
 
-    '''
+    Returns
+    -------
+    dates : :class:`list` of :class:`datetime`
+        The dates when the focalplane changed.
+    """
     ensure_focalplane_loaded()
     global _focalplane
     return [dt for dt,fdt,v in _focalplane]

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -460,6 +460,11 @@ def ensure_focalplane_loaded():
             }
         ))
 
+def get_focalplane_dates():
+    ensure_focalplane_loaded()
+    global _focalplane
+    return [dt for dt,fdt,v in _focalplane]
+
 def load_focalplane(time=None, get_time_range=False):
     """Load the focalplane state that is valid for the given time.
 

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -374,7 +374,7 @@ def load_platescale():
     ]
     try:
         _platescale = np.loadtxt(infile, usecols=[0, 1, 6, 7, 8], dtype=columns)
-    except IndexError:
+    except (IndexError,ValueError):
         # - no "arclength" column in this version of desimodel/data
         # - Get info from separate rzs file instead
 

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -460,6 +460,18 @@ def ensure_focalplane_loaded():
         ))
 
 def get_focalplane_dates():
+    ''' Returns the dates of new focalplane definitions.
+
+    There are two levels of time-dependent changes within the focalplane.  First are the
+    focalplane definitions, defined by a set of files
+       desimodel-data/data/focalplane/{desi-exclusion,desi-focalplane,desi-state}_DATE.*
+    Those are the dates returned by this function, as a list of datetime objects.
+
+    The second level is that, within the "state" table, there are changes to the states of
+    individual positioners.  (These are the dates returned when `get_time_range=True` is set
+    in load_focalplane.)
+
+    '''
     ensure_focalplane_loaded()
     global _focalplane
     return [dt for dt,fdt,v in _focalplane]
@@ -481,6 +493,12 @@ def load_focalplane(time=None, get_time_range=False):
         indexed by names that are referenced in the state.  The state
         is a Table.  The time string is the resulting UTC ISO format
         time string for the creation date of the FP model.
+
+        If get_time_range=True, returns two additional values: time_low and time_high,
+        both datetime objects giving the range of dates over which this description of the
+        focal plane is valid.  `time_high` may be None, indicating that there is no later known
+        hardware state.  In particular, these dates refer to the `state` of the positioners,
+        which are more fine-grained than the `fp` and `exclusion` objects.
     """
     # Time range over which this FP model is valid.
     time_lo = time_hi = None


### PR DESCRIPTION
This PR adds a kwarg to `load_focalplane` to optionally return the datetime ranges for which the focal plane model is valid.
It also adds a new function, `get_focalplane_dates`, that returns the list of starting valid dates.

(There are actually two nested ranges of dates -- one from the focalplane 'file sets', and the other from the entries in the `state` tables.  The `load_focalplane` returns the latter, while `get_focalplane_dates` returns the former -- because that is what is immediately available when first reading the first files.)

This is needed for some LSS optimization work: https://github.com/desihub/LSS/pull/101