### PR TITLE
Update high-level desimodel sync scripts used by cron jobs.

### DIFF
--- a/etc/desimodel_sync_kpno_cron.sh
+++ b/etc/desimodel_sync_kpno_cron.sh
@@ -44,7 +44,7 @@ export DESIMODEL_CENTRAL_REPO=${DESI_ROOT}/survey/ops/desimodel/trunk
 module use ${DESI_PRODUCT_ROOT}/modulefiles
 module load desiconda
 module load desimodules/${desimodules}
-module swap desimodel/0.17.0
+module swap -f desimodel/0.17.0
 
 echo "Using desimodel data svn trunk at ${svntrunk}" >> "${logfile}"
 export DESIMODEL="${svntrunk}"
@@ -73,9 +73,9 @@ else
     # Make sure we can load the resulting hardware model
     echo "Try loading focalplane model at ${DESIMODEL}... " >> "${logfile}"
     PYTHON_CODE=$(cat <<END
-import desimodel.io
+from fiberassign.hardware import load_hardware
 try:
-    hw = desimodel.io.load_focalplane()
+    hw = load_hardware()
     print("yes")
 except:
     print("no")
@@ -83,16 +83,16 @@ END
 )
     result="$(python3 -c "$PYTHON_CODE")"
     if [ "x$result" = "xyes" ]; then
-	echo "SUCCESS" >> "${logfile}"
-	# Now commit result
-	mesg="Appending DB sync ${calfile} to current focalplane model"
-	svn commit -m "${mesg}" "${svntrunk}/data" >> "${logfile}"
-	svn up "${svntrunk}/data" >> "${logfile}"
-	echo "Updating $DESIMODEL_CENTRAL_REPO." >> "${logfile}"
-	svn up "${DESIMODEL_CENTRAL_REPO}" >> "${logfile}"
+        echo "SUCCESS" >> "${logfile}"
+        # Now commit result
+        mesg="Appending DB sync ${calfile} to current focalplane model"
+        svn commit -m "${mesg}" "${svntrunk}/data" >> "${logfile}"
+        svn up "${svntrunk}/data" >> "${logfile}"
+        echo "Updating $DESIMODEL_CENTRAL_REPO." >> "${logfile}"
+        svn up "${DESIMODEL_CENTRAL_REPO}" >> "${logfile}"
     else
-	echo "FAIL" >> "${logfile}"
-	echo "Refusing to commit broken update.  Restore the *.previous files." >> "${logfile}"
+        echo "FAIL" >> "${logfile}"
+        echo "Refusing to commit broken update.  Restore the *.previous files." >> "${logfile}"
     fi
 fi
 


### PR DESCRIPTION
- Add missing '-f' module swap option

- Change import test to use import from fiberassign which will properly fail if exclusion polygons are not found.

- Update the "force" version of the sync script which calls the desi_sync_focalplane with the --reset option.  This script now has all the matching improvements in the cron version of the script.