### PR TITLE
Get CI running again

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,8 +19,6 @@ jobs:
                 os: [ubuntu-latest]
                 # DESI 24.4 release
                 python-version: ['3.10']
-                package-versions: ['"numpy<2" scipy matplotlib astropy',
-                                   'numpy==1.22.4 scipy==1.8.1 matplotlib==3.8.4 astropy==6.0.1']
                 fitsio-version: ['==1.2.1']
         env:
             DESIUTIL_VERSION: 3.4.2
@@ -40,11 +38,10 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
-                python -m pip install -U ${{ matrix.package-versions }}
+                python -m pip install -U --no-deps scipy
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 python -m pip install pyyaml requests
-                python -m pip install healpy
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
                 # grab surveyops snapshot
                 wget https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,7 @@ jobs:
                 scipy-version: ['==1.8.1']
                 matplotlib-version: ['==3.8.4']
         env:
-            DESIUTIL_VERSION: 3.2.5
+            DESIUTIL_VERSION: 3.4.2
             DESIMODEL_DATA: branches/test-0.19
 
         steps:
@@ -50,13 +50,10 @@ jobs:
                 python -m pip install -U 'scipy${{ matrix.scipy-version }}'
                 python -m pip install -U 'matplotlib${{ matrix.matplotlib-version }}'
                 python -m pip install healpy
-                #echo "Step 7d" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
-                # grab surveyops directory
+                # grab surveyops snapshot
                 wget https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
                 tar xvzf surveyops_2.0_ops.tar.gz
-                # ADM grab the surveyops directory.
-                #wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/
             - name: Run the test
               run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest
 
@@ -75,7 +72,7 @@ jobs:
                 scipy-version: ['==1.8.1']
                 matplotlib-version: ['==3.8.4']
         env:
-            DESIUTIL_VERSION: 3.2.5
+            DESIUTIL_VERSION: 3.4.2
             DESIMODEL_DATA: branches/test-0.17
 
         steps:
@@ -101,7 +98,7 @@ jobs:
                 python -m pip install -U 'matplotlib${{ matrix.matplotlib-version }}'
                 python -m pip install healpy
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
-                # grab surveyops directory
+                # grab surveyops snapshot
                 wget https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
                 tar xvzf surveyops_2.0_ops.tar.gz
             - name: Run the test with coverage
@@ -119,7 +116,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9']
+                python-version: ['3.10']
 
         steps:
             - name: Checkout code
@@ -160,4 +157,3 @@ jobs:
               # This is equivalent to an allowed falure.
               continue-on-error: true
               run: pycodestyle --count py/desimodel
-

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,11 +58,7 @@ jobs:
                 os: [ubuntu-latest]
                 # DESI 24.4 release
                 python-version: ['3.10']
-                astropy-version: ['==6.0.1']
                 fitsio-version: ['==1.2.1']
-                numpy-version: ['==1.22.4']
-                scipy-version: ['==1.8.1']
-                matplotlib-version: ['==3.8.4']
         env:
             DESIUTIL_VERSION: 3.4.2
             DESIMODEL_DATA: branches/test-0.17
@@ -81,14 +77,10 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
-                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install -U --no-deps scipy
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 python -m pip install pyyaml requests
-                python -m pip install -U 'scipy${{ matrix.scipy-version }}'
-                python -m pip install -U 'matplotlib${{ matrix.matplotlib-version }}'
-                python -m pip install healpy
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
                 # grab surveyops snapshot
                 wget https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
@@ -109,7 +101,6 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: ['3.10']
-
         steps:
             - name: Checkout code
               uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,6 +22,7 @@ jobs:
                 astropy-version: ['==6.0.1']
                 fitsio-version: ['==1.2.1']
                 numpy-version: ['==1.22.4']
+                scipy-version: ['==1.8.1']
         env:
             DESIUTIL_VERSION: 3.2.5
             DESIMODEL_DATA: branches/test-0.19
@@ -61,7 +62,7 @@ jobs:
                 #
                 python -m pip install pyyaml requests
                 echo "Step 7a" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
-                python -m pip install scipy
+                python -m pip install -U 'scipy${{ matrix.scipy-version }}'
                 echo "Step 7b" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install matplotlib
                 echo "Step 7c" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,37 +42,20 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
-                echo "Step 2" # -> no numpy
-                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                echo "Step 3" # -> 1.22.4
-                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
-                echo "Step 4" # -> 1.22.4
-                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip cache remove fitsio
-                echo "Step 5" # -> 1.22.4
-                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
-                echo "Step 6" # -> 1.22.4
-                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
-                #
-                #python -m pip install pyyaml requests scipy healpy matplotlib
-                #echo "Step 7" # -> 2.0.1
-                #python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
-                #
                 python -m pip install pyyaml requests
-                echo "Step 7a" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install -U 'scipy${{ matrix.scipy-version }}'
-                echo "Step 7b" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install -U 'matplotlib${{ matrix.matplotlib-version }}'
-                echo "Step 7c" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install healpy
-                echo "Step 7d" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
-                #
+                #echo "Step 7d" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
                 # ADM grab the surveyops directory.
-                wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/
+                wget https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
+                tar xvzf surveyops_2.0_ops.tar.gz
+                #wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/
             - name: Run the test
               run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
                 os: [ubuntu-latest]
                 # DESI 24.4 release
                 python-version: ['3.10']
-                package-versions: ['numpy<2 scipy matplotlib astropy',
+                package-versions: ['"numpy<2" scipy matplotlib astropy',
                                    'numpy==1.22.4 scipy==1.8.1 matplotlib==3.8.4 astropy==6.0.1']
                 fitsio-version: ['==1.2.1']
         env:
@@ -40,7 +40,7 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
-                python -m pip install -U '${{ matrix.package-versions }}'
+                python -m pip install -U ${{ matrix.package-versions }}
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 python -m pip install pyyaml requests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,10 +17,11 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9']  # fuji+guadalupe, not ready for 3.10 yet
-                astropy-version: ['==5.0', '<5.1']  # fuji+guadalupe, latest
-                fitsio-version: ['==1.1.6', '<2']  # fuji+guadalupe, latest
-                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                # DESI 24.4 release
+                python-version: ['3.10']
+                astropy-version: ['==6.0.1']
+                fitsio-version: ['==1.2.1']
+                numpy-version: ['==1.22.4']
         env:
             DESIUTIL_VERSION: 3.2.5
             DESIMODEL_DATA: branches/test-0.19
@@ -39,23 +40,34 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
-                echo "Step 2"
+                echo "Step 2" # -> no numpy
                 python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                echo "Step 3"
+                echo "Step 3" # -> 1.22.4
                 python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
-                echo "Step 4"
+                echo "Step 4" # -> 1.22.4
                 python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip cache remove fitsio
-                echo "Step 5"
+                echo "Step 5" # -> 1.22.4
                 python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
-                echo "Step 6"
+                echo "Step 6" # -> 1.22.4
                 python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
-                python -m pip install pyyaml requests scipy healpy matplotlib
-                echo "Step 7"
-                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
+                #
+                #python -m pip install pyyaml requests scipy healpy matplotlib
+                #echo "Step 7" # -> 2.0.1
+                #python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
+                #
+                python -m pip install pyyaml requests
+                echo "Step 7a" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
+                python -m pip install scipy
+                echo "Step 7b" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
+                python -m pip install matplotlib
+                echo "Step 7c" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
+                python -m pip install healpy
+                echo "Step 7d" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
+                #
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
                 # ADM grab the surveyops directory.
                 wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,13 +37,27 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
+                echo "Step 1"
+                python -c "import numpy as x; print(x.__version__)"
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
+                echo "Step 2"
+                python -c "import numpy as x; print(x.__version__)"
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
+                echo "Step 3"
+                python -c "import numpy as x; print(x.__version__)"
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                echo "Step 4"
+                python -c "import numpy as x; print(x.__version__)"
                 python -m pip cache remove fitsio
+                echo "Step 5"
+                python -c "import numpy as x; print(x.__version__)"
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
+                echo "Step 6"
+                python -c "import numpy as x; print(x.__version__)"
                 python -m pip install pyyaml requests scipy healpy matplotlib
+                echo "Step 7"
+                python -c "import numpy as x; print(x.__version__)"
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
                 # ADM grab the surveyops directory.
                 wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,11 +19,9 @@ jobs:
                 os: [ubuntu-latest]
                 # DESI 24.4 release
                 python-version: ['3.10']
-                astropy-version: ['==6.0.1']
+                package-versions: ['numpy<2 scipy matplotlib astropy',
+                                   'numpy==1.22.4 scipy==1.8.1 matplotlib==3.8.4 astropy==6.0.1']
                 fitsio-version: ['==1.2.1']
-                numpy-version: ['==1.22.4']
-                scipy-version: ['==1.8.1']
-                matplotlib-version: ['==3.8.4']
         env:
             DESIUTIL_VERSION: 3.4.2
             DESIMODEL_DATA: branches/test-0.19
@@ -42,13 +40,10 @@ jobs:
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
-                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install -U '${{ matrix.package-versions }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 python -m pip install pyyaml requests
-                python -m pip install -U 'scipy${{ matrix.scipy-version }}'
-                python -m pip install -U 'matplotlib${{ matrix.matplotlib-version }}'
                 python -m pip install healpy
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
                 # grab surveyops snapshot

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,7 @@ jobs:
                 fitsio-version: ['==1.2.1']
                 numpy-version: ['==1.22.4']
                 scipy-version: ['==1.8.1']
+                matplotlib-version: ['==3.8.4']
         env:
             DESIUTIL_VERSION: 3.2.5
             DESIMODEL_DATA: branches/test-0.19
@@ -64,7 +65,7 @@ jobs:
                 echo "Step 7a" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install -U 'scipy${{ matrix.scipy-version }}'
                 echo "Step 7b" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
-                python -m pip install matplotlib
+                python -m pip install -U 'matplotlib${{ matrix.matplotlib-version }}'
                 echo "Step 7c" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install healpy
                 echo "Step 7d" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,27 +37,25 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                echo "Step 1"
-                python -c "import numpy as x; print(x.__version__)"
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 echo "Step 2"
-                python -c "import numpy as x; print(x.__version__)"
+                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 echo "Step 3"
-                python -c "import numpy as x; print(x.__version__)"
+                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 echo "Step 4"
-                python -c "import numpy as x; print(x.__version__)"
+                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip cache remove fitsio
                 echo "Step 5"
-                python -c "import numpy as x; print(x.__version__)"
+                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 echo "Step 6"
-                python -c "import numpy as x; print(x.__version__)"
+                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 python -m pip install pyyaml requests scipy healpy matplotlib
                 echo "Step 7"
-                python -c "import numpy as x; print(x.__version__)"
+                python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
                 # ADM grab the surveyops directory.
                 wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,8 +44,8 @@ jobs:
                 python -m pip install pyyaml requests
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
                 # grab surveyops snapshot
-                wget https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
-                tar xvzf surveyops_2.0_ops.tar.gz
+                wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
+                tar xzf surveyops_2.0_ops.tar.gz
             - name: Run the test
               run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest
 
@@ -83,8 +83,8 @@ jobs:
                 python -m pip install pyyaml requests
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
                 # grab surveyops snapshot
-                wget https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
-                tar xvzf surveyops_2.0_ops.tar.gz
+                wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
+                tar xzf surveyops_2.0_ops.tar.gz
             - name: Run the test with coverage
               run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest --cov
             - name: Coveralls

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,9 +52,10 @@ jobs:
                 python -m pip install healpy
                 #echo "Step 7d" && python -c "import numpy as x; print(x.__version__)" || echo "no numpy yet"
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
-                # ADM grab the surveyops directory.
+                # grab surveyops directory
                 wget https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
                 tar xvzf surveyops_2.0_ops.tar.gz
+                # ADM grab the surveyops directory.
                 #wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/
             - name: Run the test
               run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest
@@ -66,10 +67,13 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9'] # fuji+guadalupe version
-                astropy-version: ['==5.0']  # fuji+guadalupe version
-                fitsio-version: ['==1.1.6']  # fuji+guadalupe version
-                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                # DESI 24.4 release
+                python-version: ['3.10']
+                astropy-version: ['==6.0.1']
+                fitsio-version: ['==1.2.1']
+                numpy-version: ['==1.22.4']
+                scipy-version: ['==1.8.1']
+                matplotlib-version: ['==3.8.4']
         env:
             DESIUTIL_VERSION: 3.2.5
             DESIMODEL_DATA: branches/test-0.17
@@ -92,10 +96,14 @@ jobs:
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
-                python -m pip install pyyaml requests scipy healpy matplotlib
+                python -m pip install pyyaml requests
+                python -m pip install -U 'scipy${{ matrix.scipy-version }}'
+                python -m pip install -U 'matplotlib${{ matrix.matplotlib-version }}'
+                python -m pip install healpy
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
-                # ADM grab the surveyops directory.
-                wget -e robots=off -r -np -nH --cut-dirs 7 https://data.desi.lbl.gov/public/edr/survey/ops/surveyops/tags/0.1/ops/
+                # grab surveyops directory
+                wget https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
+                tar xvzf surveyops_2.0_ops.tar.gz
             - name: Run the test with coverage
               run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest --cov
             - name: Coveralls
@@ -135,7 +143,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.9']
+                python-version: ['3.10']
 
         steps:
             - name: Checkout code

--- a/py/desimodel/test/test_fastfiberacceptance.py
+++ b/py/desimodel/test/test_fastfiberacceptance.py
@@ -28,11 +28,5 @@ class TestFiberAcceptance(unittest.TestCase):
         val = fa.value("POINT",sigmas=np.linspace(1.0,1.5,3)*fwhm_arcsec_to_sigma_um,offsets=np.zeros(3))
         assert(val.size==3)
 
-def test_suite():
-    """Allows testing of only this module with the command::
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
 if __name__ == '__main__':
     unittest.main()

--- a/py/desimodel/test/test_fieldrot.py
+++ b/py/desimodel/test/test_fieldrot.py
@@ -36,13 +36,3 @@ class TestFieldRot(unittest.TestCase):
                 maxdiff=max(maxdiff,np.abs(angle2-angle1)*3600.)
         print("Max. difference = {:3.2f} arcsec".format(maxdiff))
         assert(maxdiff<10.)
-
-def test_suite():
-    """Allows testing of only this module with the command::
-       
-       python setup.py test -m <modulename>
-    """
-
-    # usage, in base directory of desimodel :
-    # python setup.py test -m desimodel.test.test_fieldrot
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_focalplane.py
+++ b/py/desimodel/test/test_focalplane.py
@@ -275,10 +275,3 @@ class TestFocalplane(unittest.TestCase):
         del targets['TARGET_DEC']
         with self.assertRaises(ValueError):
             ok = f.targets_on_gfa(telra, teldec, targets)  #- no ra/dec
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -352,11 +352,3 @@ class TestFootprint(unittest.TestCase):
 
         # Just interesting to see how many tiles overlap a random point?
         ### print(np.bincount([len(i) for i in ret]))
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m desimodel.test.test_footprint
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_healpix.py
+++ b/py/desimodel/test/test_healpix.py
@@ -77,9 +77,3 @@ class TestHealpix(unittest.TestCase):
             for pix in tileids2pix(nside, tileid):
                 tiles = pix2tiles(nside, pix)
                 self.assertIn(tileid, tiles['TILEID'], '{} not in pix2tiles({},{})'.format(tileid, nside, pix))
-
-def test_suite():
-    """Allows testing of only this module with the command::
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_inputs.py
+++ b/py/desimodel/test/test_inputs.py
@@ -54,11 +54,3 @@ class TestInputs(unittest.TestCase):
         gfa.build_gfa_table(testdir='.')
         self.assertTrue(os.path.exists('gfa.ecsv'), "Test Failed to create a valid file!")
         os.remove('gfa.ecsv')
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -102,10 +102,3 @@ class TestInstall(unittest.TestCase):
                             install(desimodel='/opt/desimodel')
                         self.assertEqual(str(e.exception), "Mock stderr")
                     Popen.assert_called_with(['svn', 'export', 'https://desi.lbl.gov/svn/code/desimodel/trunk/data'], stderr=-1, stdout=-1)
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -386,10 +386,3 @@ class TestIO(unittest.TestCase):
             trim.trim_data(indir, self.trimdir)
             self.assertTrue(os.path.isdir(self.trimdir))
             self.assertGreater(len(list(os.walk(self.trimdir))), 1)
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_top_level.py
+++ b/py/desimodel/test/test_top_level.py
@@ -29,10 +29,3 @@ class TestTopLevel(unittest.TestCase):
             self.assertRegex(theVersion, self.versionre)
         except AttributeError:
             self.assertRegexpMatches(theVersion, self.versionre)
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_trim.py
+++ b/py/desimodel/test/test_trim.py
@@ -232,11 +232,3 @@ class TestTrim(unittest.TestCase):
             trim_quickpsf('/in/specpsf', '/out/specpsf', 'psf-quicksim.fits')
         fits['open'].assert_called_with('/in/specpsf/psf-quicksim.fits')
         fits['HDUList']().writeto.assert_called_with('/out/specpsf/psf-quicksim.fits', overwrite=True)
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desimodel/test/test_weather.py
+++ b/py/desimodel/test/test_weather.py
@@ -174,11 +174,3 @@ class TestWeather(unittest.TestCase):
             replay='Y2017,Y2007')
         self.assertTrue(np.all(probs[:365] == t['Y2017']))
         self.assertTrue(np.all(probs[365:] == t['Y2007']))
-
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
- remove test_suite() functions from test modules: the 'python setup.py test' they are meant to support is not the way we do that anymore (according to desiutil docs)
- update python modules to versions matching DESI 24.4 at NERSC
- update python to 3.10

Work In Progress -- I sent this as a PR to get the CI tests to run.
