### PR TITLE
Fix desimodel_sync script failure to update fp model

### DIFF
--- a/py/desimodel/inputs/focalplane_sync.py
+++ b/py/desimodel/inputs/focalplane_sync.py
@@ -478,7 +478,7 @@ def create_from_calibs(
             newt = Column(
                 name="TIME",
                 length=len(st["TIME"]),
-                dtype=np.dtype("a30"),
+                dtype=np.dtype("U30"),
                 description="The timestamp of the event (UTC, ISO format)",
             )
             for row, oldt in enumerate(st["TIME"]):
@@ -524,9 +524,8 @@ def create_from_calibs(
             st.add_row(row)
             n_new_states += 1
 
-            new_excl = str(
-                df["new"]["EXCLUSION"].tobytes().rstrip(b"\x00"), encoding="utf-8"
-            )
+            new_excl = df["new"]["EXCLUSION"]
+            new_excl = str(new_excl)
             if new_excl not in oldexcl:
                 oldexcl[new_excl] = excl[new_excl]
                 n_new_excl += 1

--- a/py/desimodel/inputs/focalplane_utils.py
+++ b/py/desimodel/inputs/focalplane_utils.py
@@ -431,20 +431,22 @@ def device_compare(fpold, fpnew, check):
     """
     out = dict()
     olddiff = np.setdiff1d(fpold["LOCATION"], fpnew["LOCATION"])
-    rows = np.arange(len(fpold), dtype=np.int)[fpold["LOCATION"] in olddiff]
-    for r in rows:
-        loc = fpold[r]["LOCATION"]
-        out[loc] = dict()
-        out[loc]["old"] = fpold[r]
-        out[loc]["new"] = None
+    if len(olddiff) > 0:
+        rows = np.arange(len(fpold), dtype=np.int32)[fpold["LOCATION"] in olddiff]
+        for r in rows:
+            loc = fpold[r]["LOCATION"]
+            out[loc] = dict()
+            out[loc]["old"] = fpold[r]
+            out[loc]["new"] = None
     totdiff = set(olddiff)
     newdiff = np.setdiff1d(fpnew["LOCATION"], fpold["LOCATION"])
-    rows = np.arange(len(fpnew), dtype=np.int)[fpnew["LOCATION"] in newdiff]
-    for r in rows:
-        loc = fnew[r]["LOCATION"]
-        out[loc] = dict()
-        out[loc]["new"] = fpnew[r]
-        out[loc]["old"] = None
+    if len(newdiff) > 0:
+        rows = np.arange(len(fpnew), dtype=np.int32)[fpnew["LOCATION"] in newdiff]
+        for r in rows:
+            loc = fnew[r]["LOCATION"]
+            out[loc] = dict()
+            out[loc]["new"] = fpnew[r]
+            out[loc]["old"] = None
     totdiff.update(newdiff)
 
     # Go through locations found in both tables and look for differences in
@@ -597,7 +599,7 @@ def create_tables(n_fp_rows, n_state_rows=None):
 
     """
     if n_fp_rows is None or n_fp_rows < 1:
-        raise ValueError("number of focaplane table rows must be an integer > 0")
+        raise ValueError("number of focalplane table rows must be an integer > 0")
     if n_state_rows is None:
         n_state_rows = n_fp_rows
 

--- a/py/desimodel/inputs/focalplane_utils.py
+++ b/py/desimodel/inputs/focalplane_utils.py
@@ -633,14 +633,14 @@ def create_tables(n_fp_rows, n_state_rows=None):
         Column(
             name="DEVICE_ID",
             length=n_fp_rows,
-            dtype=np.dtype("a9"),
+            dtype=np.dtype("U9"),
             data=["UNKNOWN" for x in range(n_fp_rows)],
             description="The physical device ID string",
         ),
         Column(
             name="DEVICE_TYPE",
             length=n_fp_rows,
-            dtype=np.dtype("a3"),
+            dtype=np.dtype("U3"),
             data=["NA" for x in range(n_fp_rows)],
             description="The device type (POS, ETC, FIF)",
         ),
@@ -668,7 +668,7 @@ def create_tables(n_fp_rows, n_state_rows=None):
         Column(
             name="CONDUIT",
             length=n_fp_rows,
-            dtype=np.dtype("a3"),
+            dtype=np.dtype("U3"),
             data=["NA" for x in range(n_fp_rows)],
             description="The conduit",
         ),
@@ -757,7 +757,7 @@ def create_tables(n_fp_rows, n_state_rows=None):
         Column(
             name="TIME",
             length=n_state_rows,
-            dtype=np.dtype("a30"),
+            dtype=np.dtype("U30"),
             data=["UNKNOWN" for x in range(n_state_rows)],
             description="The timestamp of the event (UTC, ISO format)",
         ),
@@ -820,7 +820,7 @@ def create_tables(n_fp_rows, n_state_rows=None):
         Column(
             name="EXCLUSION",
             length=n_state_rows,
-            dtype=np.dtype("a16"),
+            dtype=np.dtype("U16"),
             data=["UNKNOWN" for x in range(n_state_rows)],
             description="The exclusion polygon for this device",
         ),

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -432,7 +432,7 @@ def ensure_focalplane_loaded():
     fpdir = os.path.join(datadir(), "focalplane")
     fppat = re.compile(r"^desi-focalplane_(.*)\.ecsv$")
     stpat = re.compile(r"^desi-state_(.*)\.ecsv$")
-    expat = re.compile(r"^desi-exclusion_(.*)\.(?:yaml|json).*$")
+    expat = re.compile(r"^desi-exclusion_(.*)\.(?:yaml|json)(\.gz)?$")
     fpraw = dict()
     msg = "Loading focalplanes from {}".format(fpdir)
     log.debug(msg)


### PR DESCRIPTION
This turned out to be caused by an overly permissive regex in selecting the focalplane model files!

They wanted to allow yaml or json, optionally gzipped, so the regex is `r"^desi-exclusion_(.*)\.(?:yaml|json).*$")` …. BUT, the fp-sync script renames the previous exclusion file to something like `desi-exclusion_2024-08-20T04:34:57+00:00.json.gz.previous` …. which matches the regex!!  And since the files are selected using `os.walk`, the one that matches the regex and appears last in the directory listing is the one chosen!  So it was actually reading the previous exclusions list, which is why the updates weren’t working!

I also made some string (unicode) rather than bytes changes to table formats.
