### PR TITLE
Update KPNO desimodel to v0.19.2.

### DIFF
--- a/etc/desimodel_sync_kpno_cron.sh
+++ b/etc/desimodel_sync_kpno_cron.sh
@@ -44,7 +44,7 @@ export DESIMODEL_CENTRAL_REPO=${DESI_ROOT}/survey/ops/desimodel/trunk
 module use ${DESI_PRODUCT_ROOT}/modulefiles
 module load desiconda
 module load desimodules/${desimodules}
-module swap -f desimodel/0.17.0
+module swap -f desimodel/0.19.2
 
 echo "Using desimodel data svn trunk at ${svntrunk}" >> "${logfile}"
 export DESIMODEL="${svntrunk}"

--- a/etc/desimodel_sync_kpno_force.sh
+++ b/etc/desimodel_sync_kpno_force.sh
@@ -44,7 +44,7 @@ export DESIMODEL_CENTRAL_REPO=${DESI_ROOT}/survey/ops/desimodel/trunk
 module use ${DESI_PRODUCT_ROOT}/modulefiles
 module load desiconda
 module load desimodules/${desimodules}
-module swap -f desimodel/0.17.0
+module swap -f desimodel/0.19.2
 
 echo "Using desimodel data svn trunk at ${svntrunk}" >> "${logfile}"
 export DESIMODEL="${svntrunk}"


### PR DESCRIPTION
Update the KPNO scripts to use desimodel 0.19.2. This was already applied to the working copies in `~datasystems/desi_model_sync` but not altered in GitHub, as it should have been.