### PR TITLE
Switch from slackbot to email from desi cluster.

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,11 @@ desimodel Release Notes
 0.19.3 (unreleased)
 -------------------
 
+* Replace focalplane slackbot alerts with an email to slack (PR `#177`_).
 * Updated KPNO focalplane sync scripts to use desimodel 0.19.2 (PR `#176`_).
 
 .. _`#176`: https://github.com/desihub/desimodel/pull/176
+.. _`#177`: https://github.com/desihub/desimodel/pull/177
 
 0.19.2 (2024-09-17)
 -------------------

--- a/etc/desimodel_sync_kpno_cron.sh
+++ b/etc/desimodel_sync_kpno_cron.sh
@@ -92,21 +92,14 @@ END
     fi
 fi
 
-# Send notifications.
+# Send notifications. Mail out result.
+slack_email=${DESI_SLACK_MAIL_DESIMODEL_SYNC}
 
-# Get our webhook address from the environment
-slack_web_hook=${DESI_SLACKBOT_DESIMODEL_SYNC}
-
-if [ "x${slack_web_hook}" = "x" ]; then
-    echo "Environment variable DESI_SLACKBOT_DESIMODEL_SYNC not set- skipping notifications" >> "${logfile}"
+if [ "x${slack_email}" = "x" ]; then
+    echo "Environment variable DESI_SLACK_MAIL_DESIMODEL_SYNC not set- skipping notifications" >> "${logfile}"
 else
-    # Create the JSON payload.
-    slackjson="${logfile}_slack.json"
-    headtail=15
-    echo -e "{\"text\":\"Focalplane DB sync (log at \`${logfile}\`):\n\`\`\`$(head -n ${headtail} ${logfile} | sed -e "s|'|\\\'|g")\`\`\`\n(Snip)\n\`\`\`$(tail -n ${headtail} ${logfile} | sed -e "s|'|\\\'|g")\`\`\`\"}" > "${slackjson}"
-    # Post it.
-    slackerror=$(curl -X POST -H 'Content-type: application/json' --data "$(cat ${slackjson})" ${slack_web_hook})
-    echo "Slack API post  ${slackerror}" >> "${logfile}"
+    cat ${logfile} | mailx -s "Focalplane sync: ${logdate}" ${slack_email}
+    echo "Sent log to slack" >> ${logfile}
 fi
 
 echo "Sync script finished at $(date -u --iso-8601=seconds)" >> "${logfile}"

--- a/etc/desimodel_sync_kpno_force.sh
+++ b/etc/desimodel_sync_kpno_force.sh
@@ -94,21 +94,14 @@ END
     fi
 fi
 
-# Send notifications.
+# Send notifications. Mail out result.
+slack_email=${DESI_SLACK_MAIL_DESIMODEL_SYNC}
 
-# Get our webhook address from the environment
-slack_web_hook=${DESI_SLACKBOT_DESIMODEL_SYNC}
-
-if [ "x${slack_web_hook}" = "x" ]; then
-    echo "Environment variable DESI_SLACKBOT_DESIMODEL_SYNC not set- skipping notifications" >> "${logfile}"
+if [ "x${slack_email}" = "x" ]; then
+    echo "Environment variable DESI_SLACK_MAIL_DESIMODEL_SYNC not set- skipping notifications" >> "${logfile}"
 else
-    # Create the JSON payload.
-    slackjson="${logfile}_slack.json"
-    headtail=15
-    echo -e "{\"text\":\"Focalplane DB sync (log at \`${logfile}\`):\n\`\`\`$(head -n ${headtail} ${logfile} | sed -e "s|'|\\\'|g")\`\`\`\n(Snip)\n\`\`\`$(tail -n ${headtail} ${logfile} | sed -e "s|'|\\\'|g")\`\`\`\"}" > "${slackjson}"
-    # Post it.
-    slackerror=$(curl -X POST -H 'Content-type: application/json' --data "$(cat ${slackjson})" ${slack_web_hook})
-    echo "Slack API post  ${slackerror}" >> "${logfile}"
+    cat ${logfile} | mailx -s "Focalplane sync: ${logdate}" ${slack_email}
+    echo "Sent log to slack" >> ${logfile}
 fi
 
 echo "Sync script finished at $(date -u --iso-8601=seconds)" >> "${logfile}"


### PR DESCRIPTION
Inform the DESI survey-ops slack channel of the focal plane sync status using an email rather than the now-obsolete slack webhook.

Requires the environment variable `DESI_SLACK_MAIL_DESIMODEL_SYNC` to be defined in the `.bash_profile` of the `datasystems` user. The variable should point to the email used for survey-ops (see the channel integrations menu in slack).