### PR TITLE
Revive install_desimodel_data and enable desimodel usage without $DESIMODEL set

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,9 +43,8 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
-                # pip install desimodel so that we can use install_desimodel_data to get data
-                python -m pip install .
-                install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
+                # install data to checkout copy
+                PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
                 # grab surveyops snapshot
                 wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
                 tar xzf surveyops_2.0_ops.tar.gz
@@ -86,9 +85,8 @@ jobs:
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 python -m pip install pyyaml requests
-                # pip install desimodel so that we can use install_desimodel_data to get data
-                python -m pip install .
-                install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
+                # install data to checkout copy
+                PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
                 # grab surveyops snapshot
                 wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
                 tar xzf surveyops_2.0_ops.tar.gz

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,12 +43,12 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
-                svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
+                install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
                 # grab surveyops snapshot
                 wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
                 tar xzf surveyops_2.0_ops.tar.gz
             - name: Run the test
-              run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest
+              run: DESI_SURVEYOPS=$(pwd) pytest
 
     coverage:
         name: Test coverage
@@ -84,12 +84,12 @@ jobs:
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 python -m pip install pyyaml requests
-                svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data
+                install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
                 # grab surveyops snapshot
                 wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
                 tar xzf surveyops_2.0_ops.tar.gz
             - name: Run the test with coverage
-              run: DESIMODEL=$(pwd) DESI_SURVEYOPS=$(pwd) pytest --cov
+              run: DESI_SURVEYOPS=$(pwd) pytest --cov
             - name: Coveralls
               env:
                 COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,6 +43,8 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
+                # pip install desimodel so that we can use install_desimodel_data to get data
+                python -m pip install .
                 install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
                 # grab surveyops snapshot
                 wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
@@ -84,6 +86,8 @@ jobs:
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
                 python -m pip install pyyaml requests
+                # pip install desimodel so that we can use install_desimodel_data to get data
+                python -m pip install .
                 install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
                 # grab surveyops snapshot
                 wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz

--- a/bin/install_desimodel_data
+++ b/bin/install_desimodel_data
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import sys
+from desimodel.install import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desimodel Release Notes
 0.19.3 (unreleased)
 -------------------
 
-
+* Revive ``install_desimodel_data`` and enable desimodel usage without $DESIMODEL set (PR `#179`_).
 * Remove ``DesiTest`` from setup.py and warn about other deprecated features (PR `#178`_).
 * Replace focalplane slackbot alerts with an email to slack (PR `#177`_).
 * Updated KPNO focalplane sync scripts to use desimodel 0.19.2 (PR `#176`_).
@@ -13,6 +13,7 @@ desimodel Release Notes
 .. _`#176`: https://github.com/desihub/desimodel/pull/176
 .. _`#177`: https://github.com/desihub/desimodel/pull/177
 .. _`#178`: https://github.com/desihub/desimodel/pull/178
+.. _`#179`: https://github.com/desihub/desimodel/pull/179
 
 0.19.2 (2024-09-17)
 -------------------

--- a/py/desimodel/fastfiberacceptance.py
+++ b/py/desimodel/fastfiberacceptance.py
@@ -3,6 +3,7 @@ import astropy.io.fits as pyfits
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator, interp1d
 
+import desimodel.io
 
 def gaussian_fwhm(sigma):
     return 2. * np.sqrt(2. * np.log(2.)) * sigma
@@ -18,10 +19,8 @@ class FastFiberAcceptance(object):
     """
     def __init__(self,filename=None):
         if filename is None :
-            if not "DESIMODEL" in os.environ :
-                print("need environment variable DESIMODEL or specify filename in constructor")
-                raise RuntimeError("need environment variable DESIMODEL or specify filename in constructor")
-            filename=os.path.join(os.environ["DESIMODEL"],"data/throughput/galsim-fiber-acceptance.fits")
+            filename = desimodel.io.findfile('throughput/galsim-fiber-acceptance.fits')
+
         hdulist=pyfits.open(filename)
 
         sigma=hdulist["SIGMA"].data.astype('=f8')

--- a/py/desimodel/focalplane/geometry.py
+++ b/py/desimodel/focalplane/geometry.py
@@ -15,7 +15,7 @@ from astropy.table import Table
 
 from ..footprint import find_points_in_tiles, find_points_radec, get_tile_radec
 from ..io import (load_desiparams, load_fiberpos, load_platescale,
-    load_tiles, load_deviceloc)
+    load_tiles, load_deviceloc, findfile)
 
 _tile_radius_deg = None
 _tile_radius_mm = None
@@ -341,9 +341,7 @@ class FocalPlane(object):
         self._check_radec(ra, dec)
         self.ra = ra
         self.dec = dec
-        self._fiberpos_file = os.path.join(os.environ['DESIMODEL'],
-                                           'data', 'focalplane',
-                                           'fiberpos.fits')
+        self._fiberpos_file = findfile('focalplane/fiberpos.fits')
         with fits.open(self._fiberpos_file) as hdulist:
             self.fiberpos = hdulist[1].data
 

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -65,7 +65,8 @@ def get_svn_version(desimodel_version=None):
 
     return svn_version
 
-def svn_export(desimodel_version=None, svn_checkout=False):
+def svn_export(desimodel_version=None, svn_checkout=False,
+               svn_url='https://desi.lbl.gov/svn/code/desimodel'):
     """Create a :command:`svn export` command suitable for downloading a
     particular desimodel version.
 
@@ -77,6 +78,8 @@ def svn_export(desimodel_version=None, svn_checkout=False):
         otherwise trunk.
     svn_checkout : bool, default False
         If True, svn checkout instead of svn export
+    svn_url : :class:`str`, optional
+        Base URL for svn
 
     Returns
     -------
@@ -90,8 +93,7 @@ def svn_export(desimodel_version=None, svn_checkout=False):
     else:
         svn_subcommand = 'export'
 
-    return ["svn", svn_subcommand,
-            f"https://desi.lbl.gov/svn/code/desimodel/{svn_version}/data"]
+    return ["svn", svn_subcommand, f"{svn_url}/{svn_version}/data"]
 
 
 def install(desimodel=None, version=None, svn_checkout=False, dry_run=False):

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -187,6 +187,6 @@ If the data directory already exists, this script will not do anything.
         install(options.desimodel, options.desimodel_version,
                 svn_checkout=options.checkout, dry_run=options.dry_run)
     except (ValueError, RuntimeError) as e:
-        print(e.message)
+        print(e)
         return 1
     return 0

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -779,4 +779,4 @@ def datadir(surveyops=False):
         else:
             import importlib
 
-            return importlib.resources.files("desimodel").joinpath("data")
+            return str(importlib.resources.files("desimodel").joinpath("data"))

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -777,6 +777,6 @@ def datadir(surveyops=False):
         if "DESIMODEL" in os.environ:
             return os.path.abspath(os.path.join(os.environ["DESIMODEL"], "data"))
         else:
-            import pkg_resources
+            import importlib
 
-            return pkg_resources.resource_filename("desimodel", "data")
+            return importlib.resources.files("desimodel").joinpath("data")

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -11,14 +11,8 @@ from astropy.table import Table
 from .. import io
 from .. import footprint
 
-desimodel_available = True
+desimodel_available = os.path.isdir(io.datadir())
 desimodel_message = "The desimodel data set was not detected."
-try:
-    spam = os.environ['DESIMODEL']
-except KeyError:
-    desimodel_available = False
-
-
 
 class TestFootprint(unittest.TestCase):
     """Test desimodel.footprint.
@@ -84,8 +78,9 @@ class TestFootprint(unittest.TestCase):
 
     def test_ecsv(self):
         """Test consistency of ecsv vs. fits tiles files"""
-        t1 = Table.read(os.path.expandvars('$DESIMODEL/data/footprint/desi-tiles.fits'))
-        t2 = Table.read(os.path.expandvars('$DESIMODEL/data/footprint/desi-tiles.ecsv'),
+        datadir = io.datadir()
+        t1 = Table.read(f'{datadir}/footprint/desi-tiles.fits')
+        t2 = Table.read(f'{datadir}/footprint/desi-tiles.ecsv',
             format='ascii.ecsv')
         for colname in t2.colnames:
             self.assertIn(colname, t1.colnames)

--- a/py/desimodel/test/test_inputs.py
+++ b/py/desimodel/test/test_inputs.py
@@ -6,13 +6,10 @@ import unittest
 import os
 from requests.auth import HTTPDigestAuth
 from ..inputs import docdb, fiberpos, gfa, throughput
+from .. import io
 
-desimodel_available = True
+desimodel_available = os.path.isdir(io.datadir())
 desimodel_message = "The desimodel data set was not detected."
-try:
-    spam = os.environ['DESIMODEL']
-except KeyError:
-    desimodel_available = False
 
 skipMock = False
 try:

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -55,6 +55,11 @@ class TestInstall(unittest.TestCase):
         cmd = svn_export()
         self.assertEqual(cmd[2], base_url.format('trunk'))
 
+        # code version is tag-like, but we purposefully want to install a different version
+        desimodel.__version__ = '0.19.3'
+        cmd = svn_export('branches/test-0.19')
+        self.assertEqual(cmd[2], base_url.format('branches/test-0.19'))
+
         desimodel.__version__ = self.orig_version
         cmd = svn_export('trunk')
         self.assertEqual(cmd[2], base_url.format('trunk'))

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -6,6 +6,7 @@ import os
 from subprocess import CalledProcessError
 import unittest
 from ..install import default_install_dir, assert_svn_exists, svn_export, install
+import desimodel
 
 skipMock = False
 try:
@@ -19,26 +20,53 @@ class TestInstall(unittest.TestCase):
     """Test desimodel.install.
     """
 
+    def setUp(self):
+        self.orig_version = desimodel.__version__
+
+    def tearDown(self):
+        desimodel.__version__ = self.orig_version
+
     def test_default_install_dir(self):
         """Test setting default install directory.
         """
         d = os.path.dirname
         d1 = default_install_dir()
-        d2 = d(d(d(d(d(d(__file__))))))
+        d2 = d(d(__file__))
         self.assertEqual(os.path.abspath(d1), os.path.abspath(d2))
 
     def test_svn_export(self):
         """Test svn export command.
         """
         base_url = "https://desi.lbl.gov/svn/code/desimodel/{0}/data"
+
+        desimodel.__version__ = '1.2.3.dev456'
         cmd = svn_export()
         self.assertEqual(cmd[2], base_url.format('trunk'))
+
+        desimodel.__version__ = '7.8.9'
+        cmd = svn_export()
+        self.assertEqual(cmd[2], base_url.format('tags/7.8.9'))
+
+        desimodel.__version__ = '7.10'
+        cmd = svn_export()
+        self.assertEqual(cmd[2], base_url.format('tags/7.10'))
+
+        desimodel.__version__ = 'blatfoo'
+        cmd = svn_export()
+        self.assertEqual(cmd[2], base_url.format('trunk'))
+
+        desimodel.__version__ = self.orig_version
         cmd = svn_export('trunk')
         self.assertEqual(cmd[2], base_url.format('trunk'))
+
         cmd = svn_export('branches/v3')
         self.assertEqual(cmd[2], base_url.format('branches/v3'))
+
         cmd = svn_export('1.2.3')
         self.assertEqual(cmd[2], base_url.format('tags/1.2.3'))
+
+        cmd = svn_export('1.2')
+        self.assertEqual(cmd[2], base_url.format('tags/1.2'))
 
     @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
     def test_assert_svn_exists(self):

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -65,8 +65,26 @@ class TestIO(unittest.TestCase):
         if os.path.exists(self.testfile):
             os.remove(self.testfile)
 
+        self.orig_desimodel = os.getenv('DESIMODEL') # None if not set
+
     def tearDown(self):
-        pass
+        if self.orig_desimodel is not None:
+            os.environ['DESIMODEL'] = self.orig_desimodel
+        elif 'DESIMODEL' in os.environ:
+            del os.environ['DESIMODEL']
+
+    def test_findfile(self):
+        datadir = io.datadir()
+        self.assertEqual(io.findfile('blat/foo'), f'{datadir}/blat/foo')
+
+        os.environ['DESIMODEL'] = '/path/to/somewhere'
+        datadir = io.datadir()
+        self.assertEqual(datadir, '/path/to/somewhere/data')
+        self.assertEqual(io.findfile('blat/foo'), f'{datadir}/blat/foo')
+
+        del os.environ['DESIMODEL']
+        datadir = io.datadir()
+        self.assertEqual(io.findfile('blat/foo'), f'{datadir}/blat/foo')
 
     def test_reset_cache(self):
         """Test cache reset (two examples at least)

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -21,16 +21,11 @@ try:
 except ImportError:
     specter_available = False
 #
-# Try to load the DESIMODEL environment variable
+# Check if desimodel data is available.
 #
-desimodel_available = True
+desimodel_available = os.path.isdir(io.datadir())
 desimodel_message = "The desimodel data set was not detected."
-try:
-    spam = os.environ['DESIMODEL']
-except KeyError:
-    desimodel_available = False
-    specter_available = False
-    specter_message = desimodel_message
+
 #
 # Try to load the DESI_SURVEYOPS environment variable.
 #
@@ -89,7 +84,9 @@ class TestIO(unittest.TestCase):
         self.assertTrue(isinstance(io._tiles, dict))
         self.assertEqual(len(io._tiles), 0)
 
+    #- test requires both specter and desimodel data
     @unittest.skipUnless(specter_available, specter_message)
+    @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_load_throughput(self):
         """Test loading of throughput files.
         """
@@ -106,7 +103,9 @@ class TestIO(unittest.TestCase):
             self.assertTrue(np.all(t2>=0.0))
             self.assertTrue(np.all(t1>=t2))
 
+    #- test requires both specter and desimodel data
     @unittest.skipUnless(specter_available, specter_message)
+    @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_load_psf(self):
         """Test loading of PSF files.
         """
@@ -382,7 +381,7 @@ class TestIO(unittest.TestCase):
         psffile = io.findfile('specpsf/psf-b.fits')
         if os.path.getsize(psffile) > 20e6:
             from .. import trim
-            indir = os.path.join(os.getenv('DESIMODEL'), 'data')
+            indir = io.datadir()
             trim.trim_data(indir, self.trimdir)
             self.assertTrue(os.path.isdir(self.trimdir))
             self.assertGreater(len(list(os.walk(self.trimdir))), 1)

--- a/py/desimodel/test/test_weather.py
+++ b/py/desimodel/test/test_weather.py
@@ -8,6 +8,7 @@ import os
 import numpy as np
 import astropy.table
 from .. import weather as w
+from .. import io
 
 
 class TestWeather(unittest.TestCase):
@@ -166,8 +167,7 @@ class TestWeather(unittest.TestCase):
     def test_dome_frac_values(self):
         """Check correct replay of two weather years.
         """
-        DESIMODEL = os.getenv('DESIMODEL')
-        path = os.path.join(DESIMODEL, 'data', 'weather', 'daily-2007-2017.csv')
+        path = io.findfile('weather/daily-2007-2017.csv')
         t = astropy.table.Table.read(path)
         probs = w.dome_closed_fractions(
             datetime.date(2021, 1, 1), datetime.date(2023, 1, 1),

--- a/py/desimodel/weather.py
+++ b/py/desimodel/weather.py
@@ -38,6 +38,7 @@ import scipy.special
 
 import astropy.table
 
+import desimodel.io
 
 def whiten_transforms_from_cdf(x, cdf):
     """
@@ -395,8 +396,7 @@ def dome_closed_fractions(start_date, stop_date,
         raise ValueError('Expected start_date < stop_date.')
     replay = replay.split(',')
     # Load tabulated daily weather history.
-    DESIMODEL = os.getenv('DESIMODEL')
-    path = os.path.join(DESIMODEL, 'data', 'weather', 'daily-2007-2017.csv')
+    path = desimodel.io.findfile('weather/daily-2007-2017.csv')
     t = astropy.table.Table.read(path)
     if not len(t) == 365:
         raise ValueError('Invalid weather history length (expected 365).')

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup_keywords['test_suite']='{name}.test.{name}_test_suite'.format(**setup_keyw
 #
 # Autogenerate command-line scripts.
 #
-setup_keywords['entry_points'] = {'console_scripts':['install_desimodel_data = desimodel.install:main']}
+### setup_keywords['entry_points'] = {'console_scripts':['install_desimodel_data = desimodel.install:main']}
 #
 # Add internal data directories.
 #

--- a/setup.py
+++ b/setup.py
@@ -119,11 +119,11 @@ if os.path.exists('README.rst'):
 # Set other keywords for the setup function.  These are automated, & should
 # be left alone unless you are an expert.
 #
-# Treat everything in bin/ except *.rst as a script to be installed.
+# Treat everything executable in bin/ as a script to be installed.
 #
 if os.path.isdir('bin'):
     setup_keywords['scripts'] = [fname for fname in glob.glob(os.path.join('bin', '*'))
-        if not os.path.basename(fname).endswith('.rst')]
+                                 if os.access(fname, os.X_OK)]
 setup_keywords['provides'] = [setup_keywords['name']]
 setup_keywords['python_requires'] = '>=3.5'
 setup_keywords['zip_safe'] = False


### PR DESCRIPTION
**Context**: this PR simplifies end-user installation of desimodel code + data to make it easier to bootstramp a non-NERSC DESI environment e.g. for DR1 tutorials.

This PR revives the usage of `install_desimodel_data` and enables desimodel to be used without $DESIMODEL being set, in order to simplify end-user installation and usage of desimodel.  The procedure would be to pip install desimodel, and then run `install_desimodel_data` which installs the matching tag/trunk into a location that desimodel can find via `importlib.resources.files` without requiring the user to also set $DESIMODEL.  That envvar can still be used to override that location for testing alternative data, but it is no longer *required*.

Note: desispec and probably other packages still directly use $DESIMODEL and will need to be updated to use `desimodel.io.datadir` and/or `desimodel.io.findfile`, but this PR sets the groundwork for desimodel itself to not require $DESIMODEL.

### Example usage
```
$> python -m pip install git+https://github.com/desihub/desimodel.git@install-data
...
Successfully installed desimodel-0.19.2.dev767
$> install_desimodel_data
Installing desimodel data trunk to /Users/sbailey/miniforge3/envs/desitest/lib/python3.12/site-packages/desimodel
```
Note that in this case, `desimodel.__version__` is not an X.Y.Z tag and thus it installs the trunk version of data.

desimodel still works even without $DESIMODEL set:
```
$> unset DESIMODEL        # to be explicit that it isn't set
$> python -c "import desimodel.io; print(desimodel.io.datadir())"
/Users/sbailey/miniforge3/envs/desitest/lib/python3.12/site-packages/desimodel/data
$> python -c "import desimodel.io; fp = desimodel.io.load_focalplane(); print(len(fp[0]))"
5020
```

**WARNING**: A big gotcha is that `pip uninstall desimodel` will uninstall the code, but not the data since that was added post-facto outside of pip.  I don't know of a way to get pip to know how to uninstall the data too.

### Example mimicking auto-detecting to install a tag instead of a branch
```
$> git clone https://github.com/desihub/desimodel
$> cd desimodel
$> git checkout install-data
$> echo "__version__ = '0.19.2'" > py/desimodel/_version.py
$> python -m pip install .
$> install_desimodel_data
Installing desimodel data tags/0.19.2 to /Users/sbailey/miniforge3/envs/desitest/lib/python3.12/site-packages/desimodel
```
Note that in that case, I forced `desimodel.__version__` to look like a tag, so `install_desimodel_data` got the data tag instead of trunk.  `install_desimodel_data --desimodel-version X.Y.Z` can be used to override this to install a specific version (EDIT: e.g. one of the lightweight test-X.Y.Z versions), but it no longer requires the user to specify the version if the code version was already of the form X.Y or X.Y.Z and they want to install the matching data tag.

### Example using an "in-place installation" and svn checkout of trunk instead of export
```
$> git clone https://github.com/desihub/desimodel
$> cd desimodel
$> git checkout install-data
$> export PATH=$(pwd)/bin:$PATH
$> export PYTHONPATH=$(pwd)/py:$PYTHONPATH
$> install_desimodel_data --checkout
Installing desimodel data trunk to /Users/sbailey/temp/desimodel/py/desimodel
[prompts for username/password and does svn checkout instead of svn export]
$> python -c "import desimodel.io; print(desimodel.io.datadir())"
/Users/sbailey/temp/desimodel/py/desimodel/data
```

Note that you can also do `install_desimodel_data --dry-run` to see what it would do without actually installing anything.

### Other notes

* I moved `install_desimodel_data` to a script in bin/ instead of a created-on-the-fly entry point so that it could be called by an "in-place installation"
* I purposefully used `print` instead of `log.info` for more user-friendly output
* Now it only installs executable files in bin/ instead of all non-rst files.  Some of the files like bin/compare_versions.py are purposefully non-executable so that they don't pollute the path, but are only intended for expert use from a clone, not a full installation.
* I purposefully ~did~ [EDIT: did *not*] put the effort into strictly using `os.path.join()`, instead favoring `path/to/file.blat` as more readable since we only support posix systems with '/' delimeters anyway.

### Bottom line

This PR is setting the stage for the recommended end-user procedure to be
  * Use pip to install desimodel
  * Then run `install_desimodel_data`

and *not* have to separately svn export the data into a directory and set $DESIMODEL to that location.

@weaverba137 please review.