### PR TITLE
Numpy 2 compatibility

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,6 @@ jobs:
 
         env:
             DESIUTIL_VERSION: 3.5.0
-            DESIMODEL_DATA: branches/test-0.19
 
         steps:
             - name: Install System Packages
@@ -43,11 +42,16 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
-                # install data to checkout copy
-                PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
-                # grab surveyops snapshot
-                wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
-                tar xzf surveyops_2.0_ops.tar.gz
+            - name: Install desimodel data
+              env:
+                DESIMODEL_DATA: branches/test-0.19
+              run: PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
+            - name: Install surveyops snapshot
+              env:
+                SURVEYOPS_VERSION: '2.0'
+              run: |
+                wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
+                tar xzf surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
             - name: Run the test
               run: DESI_SURVEYOPS=$(pwd) pytest
 
@@ -88,7 +92,7 @@ jobs:
               run: PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
             - name: Install surveyops snapshot
               env:
-                SURVEYOPS_VERSION: 2.0
+                SURVEYOPS_VERSION: '2.0'
               run: |
                 wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
                 tar xzf surveyops_${SURVEYOPS_VERSION}_ops.tar.gz

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -154,6 +154,35 @@ jobs:
             - name: Test the documentation
               run: sphinx-build -W --keep-going -b html doc doc/_build/html
 
+    api:
+        name: API doc completeness test
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest]
+                python-version: ['3.13']
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v5
+              with:
+                python-version: ${{ matrix.python-version }}
+            - name: Install Python dependencies
+              run: python -m pip install --upgrade pip setuptools wheel
+            - name: Install DESI dependencies
+              env:
+                DESIUTIL_VERSION: 3.5.0
+              run: python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
+            - name: Generate api.rst
+              run: desi_api_file --api ./api.rst desimodel
+            - name: Compare generated api.rst to checked-in version
+              run: diff --ignore-space-change --ignore-blank-lines ./api.rst ./doc/api.rst
+
     style:
         name: Style check
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,12 +58,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                # DESI 24.4 release
                 python-version: ['3.10']
-                fitsio-version: ['==1.2.1']
-        env:
-            DESIUTIL_VERSION: 3.5.0
-            DESIMODEL_DATA: branches/test-0.19
 
         steps:
             - name: Install System Packages
@@ -80,16 +75,23 @@ jobs:
               run: |
                 python -m pip install --upgrade pip setuptools wheel
                 python -m pip install requests pyyaml numpy\<2 scipy\<1.9 matplotlib\<3.7 astropy\<6.1 healpy\<1.17
-                python -m pip install pytest pytest-cov coveralls
-                python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip cache remove fitsio
-                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
-                python -m pip install pyyaml requests
-                # install data to checkout copy
-                PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
-                # grab surveyops snapshot
-                wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_2.0_ops.tar.gz
-                tar xzf surveyops_2.0_ops.tar.gz
+                python -m pip install --no-deps --force-reinstall --ignore-installed fitsio
+                python -m pip install pytest pytest-cov coveralls
+            - name: Install DESI dependencies
+              env:
+                DESIUTIL_VERSION: 3.5.0
+              run: python -m pip install --no-deps --ignore-installed git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
+            - name: Install desimodel data
+              env:
+                DESIMODEL_DATA: branches/test-0.19
+              run: PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
+            - name: Install surveyops snapshot
+              env:
+                SURVEYOPS_VERSION: 2.0
+              run: |
+                wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
+                tar xzf surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
             - name: Run the test with coverage
               run: DESI_SURVEYOPS=$(pwd) pytest --cov
             - name: Coveralls

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,12 +16,35 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-latest]
-                python-version: ['3.10']
-                fitsio-version: ['==1.2.1', '<2']
-
-        env:
-            DESIUTIL_VERSION: 3.5.0
+                include:
+                    - os: ubuntu-latest
+                      python-version: '3.13'
+                      numpy-version: '<3.0'
+                      scipy-version: '<1.16'
+                      matplotlib-version: '<3.11'
+                      astropy-version: '<8.0'
+                      healpy-version: '<1.19'
+                    - os: ubuntu-latest
+                      python-version: '3.12'
+                      numpy-version: '<2.2'
+                      scipy-version: '<1.15'
+                      matplotlib-version: '<3.10'
+                      astropy-version: '<7.0'
+                      healpy-version: '<1.18'
+                    - os: ubuntu-latest
+                      python-version: '3.11'
+                      numpy-version: '<2.1'
+                      scipy-version: '<1.14'
+                      matplotlib-version: '<3.9'
+                      astropy-version: '<6.1'
+                      healpy-version: '<1.17'
+                    - os: ubuntu-latest
+                      python-version: '3.10'
+                      numpy-version: '<2.0'
+                      scipy-version: '<1.9'
+                      matplotlib-version: '<3.7'
+                      astropy-version: '<6.1'
+                      healpy-version: '<1.17'
 
         steps:
             - name: Install System Packages
@@ -37,11 +60,15 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install requests pyyaml numpy\<2 scipy\<1.9 matplotlib\<3.7 astropy\<6.1 healpy\<1.17
-                python -m pip install pytest
-                python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
+                python -m pip install requests pyyaml
+                python -m pip install "numpy${{ matrix.numpy-version}}" "scipy${{ matrix.scipy-version }}" "matplotlib${{ matrix.matplotlib-version }}" "astropy${{ matrix.astropy-version }}" "healpy${{ matrix.healpy-version }}"
                 python -m pip cache remove fitsio
-                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
+                python -m pip install --no-deps --force-reinstall --ignore-installed fitsio
+                python -m pip install pytest
+            - name: Install DESI dependencies
+              env:
+                DESIUTIL_VERSION: 3.5.0
+              run: python -m pip install --no-deps --ignore-installed git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,6 +1,6 @@
-=========================
-The desimodel package/API
-=========================
+=============
+desimodel API
+=============
 
 .. automodule:: desimodel
     :members:

--- a/py/desimodel/focalplane/gfa.py
+++ b/py/desimodel/focalplane/gfa.py
@@ -145,7 +145,7 @@ class GFALocations(object):
         results['GFA_LOC'] = gfa_loc[keep].astype(np.int16)
 
         assert np.all(results['GFA_LOC'] >= 0)
-        assert np.all(np.in1d(results['GFA_LOC'], self.gfa_locations))
+        assert np.all(np.isin(results['GFA_LOC'], self.gfa_locations))
 
         return results
 

--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -176,7 +176,7 @@ def tileids2pix(nside, tileids, radius=None, per_tile=False):
     tileid or list of tileids instead of table of tiles.
     '''
     tiles = load_tiles()
-    ii = np.in1d(tiles['TILEID'], tileids)
+    ii = np.isin(tiles['TILEID'], tileids)
     if np.count_nonzero(ii) == np.asarray(tileids).size:
         return tiles2pix(nside, tiles[ii], radius=radius, per_tile=per_tile)
     else:
@@ -467,7 +467,7 @@ def pix2tiles(nside, pixels, tiles=None, radius=None):
     ii = list()
     for i in range(len(tiles)):
         tilepix = hp.query_disc(nside, vec[i], radius=np.radians(radius), inclusive=True, nest=True)
-        if np.any(np.in1d(pixels, tilepix)):
+        if np.any(np.isin(pixels, tilepix)):
             ii.append(i)
     return tiles[ii]
 

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -255,7 +255,7 @@ class TestIO(unittest.TestCase):
                         np.issubdtype(t2['OBSCONDITIONS'].dtype, np.unsignedinteger) )
         self.assertLess(len(t2), len(t1))
         # All tiles in DESI are also in full set.
-        self.assertTrue(np.all(np.in1d(t2['TILEID'], t1['TILEID'])))
+        self.assertTrue(np.all(np.isin(t2['TILEID'], t1['TILEID'])))
         # I think this is the exact same test as above, except using set theory.
         self.assertEqual(len(set(t2.TILEID) - set(t1.TILEID)), 0)
         t3 = io.load_tiles(onlydesi=False, surveyops=False)
@@ -289,7 +289,7 @@ class TestIO(unittest.TestCase):
         self.assertEqual(tile_cache_id1, tile_cache_id2)
         self.assertLess(len(t2), len(t1))
         # All tiles in DESI are also in full set.
-        self.assertTrue(np.all(np.in1d(t2['TILEID'], t1['TILEID'])))
+        self.assertTrue(np.all(np.isin(t2['TILEID'], t1['TILEID'])))
         t3 = io.load_tiles(onlydesi=False)
         tile_cache_id3 = id(list(io._tiles.values())[0])
         self.assertEqual(tile_cache_id1, tile_cache_id3)


### PR DESCRIPTION
This PR makes minor changes to the desimodel code (really just `numpy.in1d()` --> `numpy.isin()`) and expands the GitHub Actions test suite to cover a wide range of Python, Numpy, ... , versions.

There was also one minor change to api.rst to make it compatible with api completeness tests.