### PR TITLE
Allow desimodel data to be removed by pip

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -112,7 +112,10 @@ jobs:
             - name: Install DESI dependencies
               env:
                 DESIUTIL_VERSION: 3.5.2
-              run: python -m pip install desiutil==${DESIUTIL_VERSION}
+                SPECTER_VERSION: 0.10.1
+              run: |
+                python -m pip install desiutil==${DESIUTIL_VERSION}
+                python -m pip install git+https://github.com/desihub/specter.git@${SPECTER_VERSION}
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19
@@ -124,10 +127,7 @@ jobs:
                 wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
                 tar xzf surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
             - name: Run the test with coverage
-              run: |
-                echo "PYTHONPATH=${PYTHONPATH}"
-                echo "DESIMODEL=${DESIMODEL}"
-                DESI_SURVEYOPS=$(pwd) pytest --cov
+              run: DESI_SURVEYOPS=$(pwd) pytest --cov
             - name: Coveralls
               env:
                 COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -116,7 +116,7 @@ jobs:
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19
-              run: PYTHONPATH=$(pwd)/py:$PYTHONPATH PATH=$(pwd)/bin:$PATH install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
+              run: PYTHONPATH=$(pwd)/py:$PYTHONPATH $(pwd)/bin/install_desimodel_data --desimodel-version ${DESIMODEL_DATA}
             - name: Install surveyops snapshot
               env:
                 SURVEYOPS_VERSION: '2.0'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -105,7 +105,7 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install requests pyyaml numpy\<1.23 scipy\<1.9 matplotlib\<3.7 astropy\<6.1 healpy\<1.17
+                python -m pip install requests pyyaml numpy\<1.23 scipy\<1.9 matplotlib\<3.7 astropy\<6.1 healpy\<1.17 numba\<0.60
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed fitsio
                 python -m pip install pytest pytest-cov coveralls

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,8 +67,8 @@ jobs:
                 python -m pip install pytest
             - name: Install DESI dependencies
               env:
-                DESIUTIL_VERSION: 3.5.0
-              run: python -m pip install --no-deps --ignore-installed git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
+                DESIUTIL_VERSION: 3.5.2
+              run: python -m pip install desiutil==${DESIUTIL_VERSION}
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19
@@ -105,14 +105,14 @@ jobs:
             - name: Install Python dependencies
               run: |
                 python -m pip install --upgrade pip setuptools wheel
-                python -m pip install requests pyyaml numpy\<2 scipy\<1.9 matplotlib\<3.7 astropy\<6.1 healpy\<1.17
+                python -m pip install requests pyyaml numpy\<1.23 scipy\<1.9 matplotlib\<3.7 astropy\<6.1 healpy\<1.17
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed fitsio
                 python -m pip install pytest pytest-cov coveralls
             - name: Install DESI dependencies
               env:
-                DESIUTIL_VERSION: 3.5.0
-              run: python -m pip install --no-deps --ignore-installed git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
+                DESIUTIL_VERSION: 3.5.2
+              run: python -m pip install desiutil==${DESIUTIL_VERSION}
             - name: Install desimodel data
               env:
                 DESIMODEL_DATA: branches/test-0.19
@@ -124,7 +124,10 @@ jobs:
                 wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
                 tar xzf surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
             - name: Run the test with coverage
-              run: DESI_SURVEYOPS=$(pwd) pytest --cov
+              run: |
+                echo "PYTHONPATH=${PYTHONPATH}"
+                echo "DESIMODEL=${DESIMODEL}"
+                DESI_SURVEYOPS=$(pwd) pytest --cov
             - name: Coveralls
               env:
                 COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+.pytest_cache
 
 # Translations
 *.mo
@@ -70,3 +71,4 @@ doc/tex/*/*.out
 
 # Editor files
 .vscode
+.env

--- a/README.rst
+++ b/README.rst
@@ -46,53 +46,29 @@ Due to its size, it is kept in the DESI svn repository.  The public, read-only
 URL for svn access is https://desi.lbl.gov/svn/code/desimodel, with the usual
 trunk/, tags/ and branches/ directories.
 
-Once you have installed this package, using either pip or desiInstall, there
-are two ways to install the accompanying data.  **For most every case, you
+Once you have installed this package, using either ``pip`` or ``desiInstall``,
+the associated data must also be installed.  **For most every case, you
 should install the tag in svn that corresponds to the same tag in git.**
 
-There are two methods to install the data, "by hand" and "scripted."
+Installing this package will create the command-line script
+``install_desimodel_data``.  It should appear in your ``PATH`` assuming
+a successful install.  ``install_desimodel_data --help`` will show you
+how to use this script.
 
-For "by hand" installs:
+You can also call the function ``desimodel.install.install()`` from
+inside other Python code.
 
-1. Find the tag you are interested in::
+When desimodel is used with other downstream code, it might become
+necessary to set the environment variable ``DESIMODEL``.
+You should set the ``DESIMODEL`` environment variable to point to the directory
+containing the data/ directory.
 
-       svn ls https://desi.lbl.gov/svn/code/desimodel/tags
+``install_desimodel_data`` with default options, may install the data in
+a relatively obscure location. To find the value to set for ``DESIMODEL``,
+you can do the following::
 
-    We'll use ``0.10.3`` in the examples below.
+    python -c "from importlib.resources import files; print(str(files('desimodel')))"
 
-2. Define the environment variable ``DESIMODEL``::
-
-       export DESIMODEL=/Users/desicollaborator/Data/desimodel/0.10.3
-
-   Note how the tag name is included.
-
-3. Create the directory and switch to it::
-
-       mkdir -p $DESIMODEL
-       cd $DESIMODEL
-
-4. Export::
-
-       svn export https://desi.lbl.gov/svn/code/desimodel/tags/0.10.3/data
-
-   Note how the tag name is the *same* as in the ``DESIMODEL`` variable.
-
-5. You may now want to add ``DESIMODEL`` to your shell startup scripts.
-
-For "scripted" installs:
-
-* Installing this package will create the command-line script
-  ``install_desimodel_data``.  It should appear in your ``PATH`` assuming
-  a successful install.  ``install_desimodel_data --help`` will show you
-  how to use this script.  Basically it is just a wrapper on the "by hand"
-  method described above.
-* You can also call the function ``desimodel.install.install()`` from
-  inside other Python code.
-
-Regardless of which method you choose, you should set the ``DESIMODEL``
-environment variable to point to the directory containing the data/
-directory.  The only real difference among all these methods is exactly
-*when* you define the ``DESIMODEL`` variable.
 
 Data Files
 ~~~~~~~~~~

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -6,8 +6,15 @@ desimodel.install
 
 Install data files not handled by pip install.
 """
-
+import os
 import re
+import sys
+import importlib.resources
+from subprocess import check_output, CalledProcessError, Popen, PIPE
+from hashlib import sha256
+from base64 import urlsafe_b64encode
+from . import __version__ as desimodel_version
+
 
 def default_install_dir():
     """Return the default install directory.
@@ -17,14 +24,12 @@ def default_install_dir():
     :class:`str`
         The path to the install directory.
     """
-    import importlib.resources
     return str(importlib.resources.files('desimodel'))
 
 
 def assert_svn_exists():
-    """Assert svn command exists and raise an informative error if not"""
-
-    from subprocess import check_output, CalledProcessError
+    """Assert svn command exists and raise an informative error if not.
+    """
     try:
         r = check_output(['svn', '--version'])
     except OSError as e:
@@ -32,9 +37,9 @@ def assert_svn_exists():
     except CalledProcessError as e:
         raise AssertionError("The svn command ({0}) on this system does not work. Output is: '{1}'.".format(e.cmd, e.output))
 
+
 def get_svn_version(desimodel_version=None):
-    """
-    Return which svn version should be checked out for given desimodel_version
+    """Return which svn version should be checked out for given `desimodel_version`
 
     Parameters
     ----------
@@ -65,6 +70,7 @@ def get_svn_version(desimodel_version=None):
 
     return svn_version
 
+
 def svn_export(desimodel_version=None, svn_checkout=False,
                svn_url='https://desi.lbl.gov/svn/code/desimodel'):
     """Create a :command:`svn export` command suitable for downloading a
@@ -76,10 +82,10 @@ def svn_export(desimodel_version=None, svn_checkout=False,
         The version X.Y.Z to download, trunk, or something of the
         form branches/... Defaults to package version if x.y.z tagged,
         otherwise trunk.
-    svn_checkout : bool, default False
-        If True, svn checkout instead of svn export
+    svn_checkout : bool, optional
+        If ``True``, :command:`svn checkout` instead of :command:`svn export`.
     svn_url : :class:`str`, optional
-        Base URL for svn
+        Base URL for svn.
 
     Returns
     -------
@@ -96,6 +102,49 @@ def svn_export(desimodel_version=None, svn_checkout=False,
     return ["svn", svn_subcommand, f"{svn_url}/{svn_version}/data"]
 
 
+def add_files_to_record(package, version, data='data', dry_run=False):
+    """Add data files to the RECORD metadata file.
+
+    Parameters
+    ----------
+    package : :class:`str`
+        The name of the package.
+    version : :class:`str`
+        The version string for `package`.
+    data : :class:`str`, optional
+        Files are added to this directory, relative to the installation directory of `package`.
+    dry_run : :class:`bool`, optional
+        If ``True``, do not modify the RECORD file, just print the
+
+    Returns
+    -------
+    :class:`list`
+        The lines that were added to the RECORD file.
+    """
+    root = default_install_dir()
+    site_packages = os.path.dirname(root)
+    meta_record = os.path.join(site_packages, f"{package}-{version}.dist-info", 'RECORD')
+    lines = list()
+    for dirpath, dirnames, filenames in os.walk(os.path.join(root, data)):
+        for file in filenames:
+            full_name = os.path.join(dirpath, file)
+            rel_name = full_name.replace(site_packages + '/', '')
+            st = os.stat(full_name)
+            with open(full_name, 'rb') as FILE:
+                file_bytes = FILE.read()
+            sh = sha256()
+            sh.update(file_bytes)
+            sha = urlsafe_b64encode(sh.digest()).decode('utf-8').strip('=')
+            lines.append(f"{rel_name},sha256={sha},{st.st_size:d}")
+    if dry_run:
+        for lin in lines:
+            print(lin)
+    else:
+        with open(meta_record, 'a') as RECORD:
+            RECORD.write('\r\n'.join(lines) + '\r\n')
+    return lines
+
+
 def install(desimodel=None, version=None, svn_checkout=False, dry_run=False):
     """Primary workhorse function.
 
@@ -104,33 +153,38 @@ def install(desimodel=None, version=None, svn_checkout=False, dry_run=False):
     desimodel : :class:`str`, optional
         Allows the install directory to be explicitly set.
     version : :class:`str`, optional
-        Allows the desimodel version to be explicitly set.
-    svn_checkout : bool, default False
-        If True, svn checkout instead of svn export
-    dry_run : bool, default False
-        If True, print commands but don't actually get the data
+        Allows the desimodel *data* version to be explicitly set.
+    svn_checkout : bool, optional
+        If ``True``, :command:`svn checkout` instead of :command:`svn export`.
+    dry_run : bool, optional
+        If ``True``, print commands but don't actually get the data.
+
+    Returns
+    -------
+    :class:`list`
+        The list of files added, in :command:`pip`' RECORD_ metadata format.
 
     Raises
     ------
     :class:`RuntimeError`
         Standard error output from svn export command when status is non-zero.
+
+    .. _RECORD: https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-record-file
     """
-    from os import chdir, environ
-    from os.path import exists, join
-    from subprocess import Popen, PIPE
     try:
-        install_dir = environ['DESIMODEL']
+        install_dir = os.environ['DESIMODEL']
     except KeyError:
         if desimodel is not None:
             install_dir = desimodel
         else:
             install_dir = default_install_dir()
-    if exists(join(install_dir, 'data')):
-        raise ValueError("{0} already exists!".format(join(install_dir,
-                                                           'data')))
+
+    if os.path.exists(os.path.join(install_dir, 'data')):
+        raise ValueError("{0} already exists!".format(os.path.join(install_dir, 'data')))
+
     assert_svn_exists()
 
-    chdir(install_dir)
+    os.chdir(install_dir)
 
     svn_version = get_svn_version(version)
     print(f'Installing desimodel data {svn_version} to {install_dir}')
@@ -146,6 +200,14 @@ def install(desimodel=None, version=None, svn_checkout=False, dry_run=False):
         if status != 0:
             raise RuntimeError(err.rstrip())
 
+    if install_dir == default_install_dir():
+        added = add_files_to_record('desimodel', desimodel_version,
+                                    data='data',
+                                    dry_run=dry_run)
+        return added
+
+    return []
+
 
 def main():
     """Entry point for the :command:`install_desimodel_data` script.
@@ -155,7 +217,6 @@ def main():
     :class:`int`
         An integer suitable for passing to :func:`sys.exit`.
     """
-    from sys import argv
     from argparse import ArgumentParser
     desc = """Install desimodel data.
 
@@ -171,7 +232,7 @@ locations, in order of preference:
 
 If the data directory already exists, this script will not do anything.
 """.format(default_install_dir())
-    parser = ArgumentParser(description=desc, prog=argv[0])
+    parser = ArgumentParser(description=desc, prog=sys.argv[0])
     parser.add_argument('-d', '--desimodel', action='store', dest='desimodel',
                         metavar='DESIMODEL',
                         help=('Place the data/ directory in this directory. ' +
@@ -186,8 +247,8 @@ If the data directory already exists, this script will not do anything.
                         help="Print actions but don't actually install the data")
     options = parser.parse_args()
     try:
-        install(options.desimodel, options.desimodel_version,
-                svn_checkout=options.checkout, dry_run=options.dry_run)
+        added = install(options.desimodel, options.desimodel_version,
+                        svn_checkout=options.checkout, dry_run=options.dry_run)
     except (ValueError, RuntimeError) as e:
         print(e)
         return 1

--- a/py/desimodel/install.py
+++ b/py/desimodel/install.py
@@ -123,7 +123,10 @@ def add_files_to_record(package, version, data='data', dry_run=False):
     """
     root = default_install_dir()
     site_packages = os.path.dirname(root)
-    meta_record = os.path.join(site_packages, f"{package}-{version}.dist-info", 'RECORD')
+    meta_dir = os.path.join(site_packages, f"{package}-{version}.dist-info")
+    if not os.path.isdir(meta_dir):
+        return []
+    meta_record = os.path.join(meta_dir, 'RECORD')
     lines = list()
     for dirpath, dirnames, filenames in os.walk(os.path.join(root, data)):
         for file in filenames:
@@ -162,14 +165,14 @@ def install(desimodel=None, version=None, svn_checkout=False, dry_run=False):
     Returns
     -------
     :class:`list`
-        The list of files added, in :command:`pip`' RECORD_ metadata format.
+        The list of files added, in :command:`pip` `RECORD`_ metadata format.
 
     Raises
     ------
     :class:`RuntimeError`
         Standard error output from svn export command when status is non-zero.
 
-    .. _RECORD: https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-record-file
+    .. _`RECORD`: https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-record-file
     """
     try:
         install_dir = os.environ['DESIMODEL']

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -407,6 +407,7 @@ def load_platescale():
     ]
     try:
         warnings.warn(infile, UserWarning)
+        warnings.warn(os.getcwd(), UserWarning)
         _platescale = np.loadtxt(infile, usecols=[0, 1, 6, 7, 8], dtype=columns)
     except (IndexError,ValueError):
         # - no "arclength" column in this version of desimodel/data

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -406,6 +406,7 @@ def load_platescale():
         ("arclength", "f8"),
     ]
     try:
+        warnings.warn(infile, UserWarning)
         _platescale = np.loadtxt(infile, usecols=[0, 1, 6, 7, 8], dtype=columns)
     except (IndexError,ValueError):
         # - no "arclength" column in this version of desimodel/data

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -415,7 +415,6 @@ def load_platescale():
         rzs = Table.read(findfile("focalplane/rzsn.txt"), format="ascii")
 
         from scipy.interpolate import interp1d
-        from numpy.lib.recfunctions import append_fields
 
         arclength = interp1d(rzs["R"], rzs["S"], kind="quadratic")
         _platescale["arclength"] = arclength(_platescale["radius"])

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -406,8 +406,6 @@ def load_platescale():
         ("arclength", "f8"),
     ]
     try:
-        warnings.warn(infile, UserWarning)
-        warnings.warn(os.getcwd(), UserWarning)
         _platescale = np.loadtxt(infile, usecols=[0, 1, 6, 7, 8], dtype=columns)
     except (IndexError,ValueError):
         # - no "arclength" column in this version of desimodel/data

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -3,17 +3,13 @@
 """Test desimodel.install.
 """
 import os
+import shutil
+from tempfile import mkdtemp
 from subprocess import CalledProcessError
 import unittest
-from ..install import default_install_dir, assert_svn_exists, svn_export, install
+from unittest.mock import patch, MagicMock, call
+from ..install import default_install_dir, assert_svn_exists, svn_export, install, add_files_to_record
 import desimodel
-
-skipMock = False
-try:
-    from unittest.mock import patch, MagicMock
-except ImportError:
-    # Python 2
-    skipMock = True
 
 
 class TestInstall(unittest.TestCase):
@@ -22,9 +18,11 @@ class TestInstall(unittest.TestCase):
 
     def setUp(self):
         self.orig_version = desimodel.__version__
+        self.tmp_dir = mkdtemp()
 
     def tearDown(self):
         desimodel.__version__ = self.orig_version
+        shutil.rmtree(self.tmp_dir)
 
     def test_default_install_dir(self):
         """Test setting default install directory.
@@ -40,7 +38,8 @@ class TestInstall(unittest.TestCase):
         base_url = "https://desi.lbl.gov/svn/code/desimodel/{0}/data"
 
         desimodel.__version__ = '1.2.3.dev456'
-        cmd = svn_export()
+        cmd = svn_export(svn_checkout=True)
+        self.assertEqual(cmd[1], 'checkout')
         self.assertEqual(cmd[2], base_url.format('trunk'))
 
         desimodel.__version__ = '7.8.9'
@@ -73,27 +72,53 @@ class TestInstall(unittest.TestCase):
         cmd = svn_export('1.2')
         self.assertEqual(cmd[2], base_url.format('tags/1.2'))
 
-    @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
-    def test_assert_svn_exists(self):
+    @patch('desimodel.install.check_output')
+    def test_assert_svn_exists(self, mock_output):
         """Test the check for svn presence.
         """
-        mock = MagicMock(return_value=0)
-        with patch('subprocess.check_output', mock):
+        mock_output.return_value = 0
+        assert_svn_exists()
+        mock_output.assert_called_with(['svn', '--version'])
+        mock_output.side_effect = OSError(12345, "Mock error")
+        with self.assertRaises(AssertionError) as e:
             assert_svn_exists()
-        mock.assert_called_with(['svn', '--version'])
-        mock = MagicMock(side_effect=OSError(12345, "Mock error"))
-        with patch('subprocess.check_output', mock):
-            with self.assertRaises(AssertionError) as e:
-                assert_svn_exists()
-            self.assertEqual(str(e.exception), "svn command is not executable. Install svn to use the install script. Original Error is: 'Mock error'.")
-        mock = MagicMock(side_effect=CalledProcessError(1, 'svn', 'Mock stdout', 'Mock stderr'))
-        with patch('subprocess.check_output', mock):
-            with self.assertRaises(AssertionError) as e:
-                assert_svn_exists()
-            self.assertEqual(str(e.exception), "The svn command (svn) on this system does not work. Output is: 'Mock stdout'.")
+        self.assertEqual(str(e.exception), "svn command is not executable. Install svn to use the install script. Original Error is: 'Mock error'.")
+        mock_output.side_effect = CalledProcessError(1, 'svn', 'Mock stdout', 'Mock stderr')
+        with self.assertRaises(AssertionError) as e:
+            assert_svn_exists()
+        self.assertEqual(str(e.exception), "The svn command (svn) on this system does not work. Output is: 'Mock stdout'.")
 
-    @unittest.skipIf(skipMock, "Skipping test that requires unittest.mock.")
-    def test_install(self):
+    @patch('builtins.print')
+    @patch('desimodel.install.default_install_dir')
+    def test_add_files_to_record(self, mock_dir, mock_print):
+        """Test updating the RECORD metadata file.
+        """
+        version = '1.2.3'
+        os.makedirs(os.path.join(self.tmp_dir, 'desimodel', 'data', 'weather'))
+        desimodel_meta = os.path.join(self.tmp_dir, f'desimodel-{version}.dist-info')
+        os.makedirs(desimodel_meta)
+        record_file = os.path.join(desimodel_meta, 'RECORD')
+        with open(record_file, 'w') as RECORD:
+            RECORD.write('')
+        with open(os.path.join(self.tmp_dir, 'desimodel', 'data', 'desi.yaml'), 'w') as YAML:
+            YAML.write("foo: bar\n")
+        with open(os.path.join(self.tmp_dir, 'desimodel', 'data', 'weather', 'weather.csv'), 'w') as CSV:
+            CSV.write("day,temp\r\n20201212,15.0\r\n")
+        self.assertTrue(os.path.exists(record_file))
+        mock_dir.return_value = os.path.join(self.tmp_dir, 'desimodel')
+        added = add_files_to_record('desimodel', version)
+        self.assertEqual(len(added), 2)
+        self.assertEqual(added[0], 'desimodel/data/desi.yaml,sha256=HavE48u9aggYvUYPOmyYVb_pXVBsdHJrwPLtsK7LH04,9')
+        self.assertEqual(added[1], 'desimodel/data/weather/weather.csv,sha256=Jbi1Ugess7xrprvN2BkNvPQSRYcG2WRxylKXgaKxCA0,25')
+        #
+        # Dry-run mode
+        #
+        added = add_files_to_record('desimodel', version, data='data', dry_run=True)
+        mock_print.assert_has_calls([call('desimodel/data/desi.yaml,sha256=HavE48u9aggYvUYPOmyYVb_pXVBsdHJrwPLtsK7LH04,9'),
+                                     call('desimodel/data/weather/weather.csv,sha256=Jbi1Ugess7xrprvN2BkNvPQSRYcG2WRxylKXgaKxCA0,25')])
+
+    @patch('os.path.exists')
+    def test_install(self, mock_exists):
         """Test the install function.
         """
         with patch.dict('os.environ'):
@@ -101,25 +126,25 @@ class TestInstall(unittest.TestCase):
                 del os.environ['DESIMODEL']
             except KeyError:
                 pass
-            with patch('os.path.exists') as exists:
-                exists.return_value = True
-                with self.assertRaises(ValueError) as e:
-                    install(desimodel='/opt/desimodel')
-                self.assertEqual(str(e.exception), "/opt/desimodel/data already exists!")
-            exists.assert_called_with('/opt/desimodel/data')
-            with patch('os.path.exists') as exists:
-                exists.return_value = True
-                with self.assertRaises(ValueError) as e:
-                    install()
-                self.assertEqual(str(e.exception), "{0}/data already exists!".format(default_install_dir()))
-            exists.assert_called_with('{0}/data'.format(default_install_dir()))
+            mock_exists.return_value = True
+            with self.assertRaises(ValueError) as e:
+                install(desimodel='/opt/desimodel')
+            self.assertEqual(str(e.exception), "/opt/desimodel/data already exists!")
+            mock_exists.assert_called_once_with('/opt/desimodel/data')
+            mock_exists.reset_mock()
+            with self.assertRaises(ValueError) as e:
+                install()
+            self.assertEqual(str(e.exception), "{0}/data already exists!".format(default_install_dir()))
+            mock_exists.assert_called_once_with('{0}/data'.format(default_install_dir()))
+            mock_exists.reset_mock()
             os.environ['DESIMODEL'] = '/opt/desimodel'
-            with patch('os.path.exists') as exists:
-                exists.return_value = True
-                with self.assertRaises(ValueError) as e:
-                    install()
-                self.assertEqual(str(e.exception), "/opt/desimodel/data already exists!")
-            exists.assert_called_with('/opt/desimodel/data')
+            with self.assertRaises(ValueError) as e:
+                install()
+            self.assertEqual(str(e.exception), "/opt/desimodel/data already exists!")
+            mock_exists.assert_called_once_with('/opt/desimodel/data')
+            mock_exists.reset_mock()
+
+        mock_exists.return_value = False
         with patch.dict('os.environ'):
             try:
                 del os.environ['DESIMODEL']
@@ -127,11 +152,20 @@ class TestInstall(unittest.TestCase):
                 pass
             with patch('desimodel.install.assert_svn_exists'):
                 with patch('os.chdir'):
-                    with patch('subprocess.Popen') as Popen:
+                    with patch('desimodel.install.Popen') as Popen:
                         proc = Popen.return_value
                         proc.communicate.return_value = ('Mock stdout', 'Mock stderr')
                         proc.returncode = 1
                         with self.assertRaises(RuntimeError) as e:
                             install(desimodel='/opt/desimodel')
                         self.assertEqual(str(e.exception), "Mock stderr")
-                    Popen.assert_called_with(['svn', 'export', 'https://desi.lbl.gov/svn/code/desimodel/trunk/data'], stderr=-1, stdout=-1)
+                    Popen.assert_called_once_with(['svn', 'export', 'https://desi.lbl.gov/svn/code/desimodel/trunk/data'], stderr=-1, stdout=-1)
+                with patch('builtins.print') as mock_print:
+                    with patch('desimodel.install.default_install_dir') as mock_dir:
+                        mock_dir.return_value = 'foo'
+                        version='1.2.3'
+                        desimodel_code = os.path.join(self.tmp_dir, 'desimodel')
+                        os.makedirs(desimodel_code)
+                        added = install(desimodel=desimodel_code, version=version, svn_checkout=False, dry_run=True)
+                        mock_print.assert_has_calls([call(f'Installing desimodel data tags/{version} to {desimodel_code}'),
+                                                     call(f'Dry run, would have run "svn export https://desi.lbl.gov/svn/code/desimodel/tags/{version}/data"')])

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -162,12 +162,12 @@ class TestInstall(unittest.TestCase):
                             install(desimodel='/opt/desimodel')
                         self.assertEqual(str(e.exception), "Mock stderr")
                     Popen.assert_called_once_with(['svn', 'export', 'https://desi.lbl.gov/svn/code/desimodel/trunk/data'], stderr=-1, stdout=-1)
-                with patch('builtins.print') as mock_print:
-                    with patch('desimodel.install.default_install_dir') as mock_dir:
-                        mock_dir.return_value = 'foo'
-                        version='1.2.3'
-                        desimodel_code = os.path.join(self.tmp_dir, 'desimodel')
-                        os.makedirs(desimodel_code)
-                        added = install(desimodel=desimodel_code, version=version, svn_checkout=False, dry_run=True)
-                        mock_print.assert_has_calls([call(f'Installing desimodel data tags/{version} to {desimodel_code}'),
-                                                     call(f'Dry run, would have run "svn export https://desi.lbl.gov/svn/code/desimodel/tags/{version}/data"')])
+                    with patch('builtins.print') as mock_print:
+                        with patch('desimodel.install.default_install_dir') as mock_dir:
+                            mock_dir.return_value = 'foo'
+                            version='1.2.3'
+                            desimodel_code = os.path.join(self.tmp_dir, 'desimodel')
+                            os.makedirs(desimodel_code)
+                            added = install(desimodel=desimodel_code, version=version, svn_checkout=False, dry_run=True)
+                            mock_print.assert_has_calls([call(f'Installing desimodel data tags/{version} to {desimodel_code}'),
+                                                        call(f'Dry run, would have run "svn export https://desi.lbl.gov/svn/code/desimodel/tags/{version}/data"')])

--- a/py/desimodel/test/test_install.py
+++ b/py/desimodel/test/test_install.py
@@ -94,7 +94,10 @@ class TestInstall(unittest.TestCase):
         """Test updating the RECORD metadata file.
         """
         version = '1.2.3'
+        mock_dir.return_value = os.path.join(self.tmp_dir, 'desimodel')
         os.makedirs(os.path.join(self.tmp_dir, 'desimodel', 'data', 'weather'))
+        added = add_files_to_record('desimodel', version)
+        self.assertEqual(len(added), 0)
         desimodel_meta = os.path.join(self.tmp_dir, f'desimodel-{version}.dist-info')
         os.makedirs(desimodel_meta)
         record_file = os.path.join(desimodel_meta, 'RECORD')
@@ -105,7 +108,6 @@ class TestInstall(unittest.TestCase):
         with open(os.path.join(self.tmp_dir, 'desimodel', 'data', 'weather', 'weather.csv'), 'w') as CSV:
             CSV.write("day,temp\r\n20201212,15.0\r\n")
         self.assertTrue(os.path.exists(record_file))
-        mock_dir.return_value = os.path.join(self.tmp_dir, 'desimodel')
         added = add_files_to_record('desimodel', version)
         self.assertEqual(len(added), 2)
         self.assertEqual(added[0], 'desimodel/data/desi.yaml,sha256=HavE48u9aggYvUYPOmyYVb_pXVBsdHJrwPLtsK7LH04,9')

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -169,6 +169,7 @@ class TestIO(unittest.TestCase):
     def test_load_platescale(self):
         """Test loading platescale.txt file.
         """
+        self.assertTrue(os.path.exists(io.findfile('focalplane/platescale.txt')))
         p1 = io.load_platescale()
         p2 = io.load_platescale()
         self.assertTrue(p1 is p2)  #- caching worked
@@ -387,9 +388,9 @@ class TestIO(unittest.TestCase):
 
         self.assertEqual(sorted(tt.dtype.names), sorted(te.colnames))
 
-        for program in set(tf['PROGRAM']):
-            self.assertTrue((program[-1] != ' ') and (program[-1] != b' '))
         for program in set(tt['PROGRAM']):
+            self.assertTrue((program[-1] != ' ') and (program[-1] != b' '))
+        for program in set(te['PROGRAM']):
             self.assertTrue((program[-1] != ' ') and (program[-1] != b' '))
 
 

--- a/py/desimodel/test/test_io.py
+++ b/py/desimodel/test/test_io.py
@@ -4,7 +4,6 @@
 """
 import os
 import sys
-import uuid
 import tempfile
 import datetime
 import numpy as np
@@ -30,7 +29,7 @@ desimodel_message = "The desimodel data set was not detected."
 # Try to load the DESI_SURVEYOPS environment variable.
 #
 surveyops_available = True
-surveyops_message = "The DESI_SURVEYOPS directory was not detected"
+surveyops_message = "The DESI_SURVEYOPS directory was not detected."
 try:
     _ = os.environ['DESI_SURVEYOPS']
 except KeyError:
@@ -42,9 +41,9 @@ class TestIO(unittest.TestCase):
     """
     @classmethod
     def setUpClass(cls):
-        global specter_available, desimodel_available
         cls.specter_available = specter_available
         cls.desimodel_available = desimodel_available
+        cls.surveyops_available = surveyops_available
         cls.tempdir = tempfile.mkdtemp(prefix='testio-')
         cls.trimdir = os.path.join(cls.tempdir, 'trim')
         cls.testfile = os.path.join(cls.tempdir, 'test-abc123.fits')
@@ -172,7 +171,7 @@ class TestIO(unittest.TestCase):
         self.assertTrue(os.path.exists(io.findfile('focalplane/platescale.txt')))
         p1 = io.load_platescale()
         p2 = io.load_platescale()
-        self.assertTrue(p1 is p2)  #- caching worked
+        self.assertIs(p1, p2)  #- caching worked
 
     @unittest.skipUnless(desimodel_available, desimodel_message)
     def test_get_focalplane_dates(self):


### PR DESCRIPTION
This PR allows `pip` to clean up desimodel data installed via `install_desimodel_data`, although only in the case where a user has specified the standard install location.

Example uninstall scenario:
```
pip install git+https://github.com/desihub/desimodel.git@0.19.2
# will install in $prefix/lib/python3.x/site-packages/desimodel/data
install_desimodel_data
pip uninstall desimodel
# $prefix/lib/python3.x/site-packages/desimodel should be completely gone
```

Example upgrade scenario:
```
pip install git+https://github.com/desihub/desimodel.git@0.19.0
# will install in $prefix/lib/python3.x/site-packages/desimodel/data
install_desimodel_data
pip install -U git+https://github.com/desihub/desimodel.git@0.19.2
# $prefix/lib/python3.x/site-packages/desimodel/data will need to be reinstalled, since it's a different tag anyway, but the data directory should be gone, so there's nothing to prevent the installation
install_desimodel_data
```

If the data are installed elsewhere, via setting `DESIMODEL` or some other method, the user is responsible for cleaning that up.

If `install_desimodel_data` is being run from *e.g.* a git checkout, especially in a test environment such as GitHub Actions, the pip metadata will not exist, and the modification of the pip metadata will be skipped.

@sbailey, I encourage testing in your own pip environment (a throw-away venv) a few times before merging.