### PR TITLE
BACKUP program now has 2 passes

### DIFF
--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -53,13 +53,13 @@ class TestFootprint(unittest.TestCase):
         # ADM in the real survey data there is no GRAY program...
 #        self.assertEqual(len(footprint.program2pass('GRAY')), 1)
         # ADM ...but there is a BACKUP program.
-        self.assertEqual(len(footprint.program2pass('BACKUP')), 1)
+        self.assertGreaterEqual(len(footprint.program2pass('BACKUP')), 1)
         self.assertEqual(len(footprint.program2pass('BRIGHT')), 5)
 
         passes = footprint.program2pass(['DARK', 'BACKUP', 'BRIGHT'])
         self.assertEqual(len(passes), 3)
         self.assertEqual(len(passes[0]), 7)
-        self.assertEqual(len(passes[1]), 1)
+        self.assertGreaterEqual(len(passes[1]), 1)
         self.assertEqual(len(passes[2]), 5)
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This PR fixes a test failure due to the BACKUP program now having two passes instead of one.  Rather than hardcode 2, I changed the test to be greater than or equal to 1 so that they will continue to work with older tags of desisurveyops in svn.  i.e. the test checks that a backup program exists, but doesn't hardcode exactly how many layers it expects.