### PR TITLE
update is_point_in_desi tests

### DIFF
--- a/py/desimodel/footprint.py
+++ b/py/desimodel/footprint.py
@@ -496,8 +496,9 @@ def is_point_in_desi(tiles, ra, dec, radius=None, return_tile_index=False, worke
             must match the size of `ra`.
         radius (float, optional): Tile radius in degrees;
             if `None` use :func:`desimodel.focalplane.get_tile_radius_deg`.
-        return_tile_index (bool, optional): If ``True``, return the index of
-            the nearest tile in tiles array.
+        return_tile_index (bool, optional): If ``True``, also return indices of
+            the nearest overlapping tiles in tiles array. For points that
+            do not overlap a tile, the index should be ignored.
         workers (int, optional): Number of workers to pass to KDTree search. 
             Defaults to -1 i.e. all available threads.
 
@@ -525,6 +526,7 @@ def is_point_in_desi(tiles, ra, dec, radius=None, return_tile_index=False, worke
 
     #indesi = d < threshold
     indesi = np.isfinite(d)
+
     if return_tile_index:
         return indesi, i
     else:

--- a/py/desimodel/test/test_footprint.py
+++ b/py/desimodel/test/test_footprint.py
@@ -136,11 +136,27 @@ class TestFootprint(unittest.TestCase):
         ret = footprint.is_point_in_desi(tiles, (0.0,), (-2.0,), radius=1.605, return_tile_index=True)
         self.assertEqual(ret, ([True], [0]))
 
+        ret = footprint.is_point_in_desi(tiles, 1.1, -1.1, return_tile_index=True)
+        self.assertEqual(ret, (True, 1))
+
+        ret = footprint.is_point_in_desi(tiles, 1.9, 0.9, return_tile_index=False)
+        self.assertEqual(ret, True)
+
+        #- points not in DESI, index is meaningless
+        badindex = len(tiles)  # largest valid index is len(tiles)-1
         ret = footprint.is_point_in_desi(tiles, 0.0, -3.7, radius=1.605, return_tile_index=True)
-        self.assertEqual(ret, (False, 0))
+        self.assertEqual(ret, (False, badindex))
 
         ret = footprint.is_point_in_desi(tiles, -3.0, -2.0, radius=1.605, return_tile_index=True)
-        self.assertEqual(ret, (False, 0))
+        self.assertEqual(ret, (False, badindex))
+
+        ret = footprint.is_point_in_desi(tiles, -3.0, -2.0, radius=1.605, return_tile_index=False)
+        self.assertEqual(ret, False)
+
+        #- one point in DESI, one point not
+        ret = footprint.is_point_in_desi(tiles, [2.0, -3.0], [1.0, -2.0], radius=1.605, return_tile_index=True)
+        self.assertEqual(list(ret[0]), [True,False])
+        self.assertEqual(list(ret[1]), [2,4])
 
         ret = footprint.is_point_in_desi(tiles, tiles['RA'], tiles['DEC'], radius=1.605)
         self.assertEqual(len(ret), len(tiles))


### PR DESCRIPTION
This PR is a followup to #187, clarifying the docstring and expanding the tests to cover the cases for what the returned indices should be when `is_point_in_desi(tiles, ra, dec, return_tile_index=True)` includes points that are not covered by tiles.  Previously it returned the nearest tile even if that tile didn't overlap the point.  After #187, it now returns `len(tiles)` for an indices that are not covered by tiles, i.e. a purposefully invalid index instead of an index to a nearby tile that doesn't actually overlap the point.