### PR TITLE
add check that datadir exists

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -15,7 +15,9 @@ desimodel Release Notes
   - Explicitly add dependency on configobj_
 
 * Update focalplane sync scripts to catch errors in logs (PR `#195`_).
+* Log warning message if desimodel data isn't installed (PR `#197`_).
 
+.. _`#197`: https://github.com/desihub/desimodel/pull/197
 .. _`#195`: https://github.com/desihub/desimodel/pull/195
 .. _`#193`: https://github.com/desihub/desimodel/pull/193
 .. _`#192`: https://github.com/desihub/desimodel/pull/192

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,7 +42,7 @@ extensions = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
     'healpy': ('https://healpy.readthedocs.io/en/stable/', None)

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -779,3 +779,11 @@ def datadir(surveyops=False):
             import importlib
 
             return str(importlib.resources.files("desimodel").joinpath("data"))
+
+def _check_datadir():
+    """Print warning message if desimodel data directory doesn't exist"""
+    _datadir = datadir()
+    if not os.path.isdir(_datadir):
+        log.warning(f'Missing {_datadir}; please run "install_desimodel_data" from the commandline or "desimodel.install.main()" from a python prompt')
+
+_check_datadir()

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -784,7 +784,7 @@ def _check_datadir():
     """Print warning message if desimodel data directory doesn't exist"""
     _datadir = datadir()
     if not os.path.isdir(_datadir):
-        log.warning(f'Missing {_datadir}; please run "install_desimodel_data" from the command line or "desimodel.install.main()" from a python prompt; see https://github.com/desihub/desimodel for details.')
+        log.warning(f'Missing {_datadir}; please run "install_desimodel_data" from the command line or "desimodel.install.install()" from a python prompt; see https://github.com/desihub/desimodel for details.')
         return False
     else:
         return True

--- a/py/desimodel/io.py
+++ b/py/desimodel/io.py
@@ -784,6 +784,9 @@ def _check_datadir():
     """Print warning message if desimodel data directory doesn't exist"""
     _datadir = datadir()
     if not os.path.isdir(_datadir):
-        log.warning(f'Missing {_datadir}; please run "install_desimodel_data" from the commandline or "desimodel.install.main()" from a python prompt')
+        log.warning(f'Missing {_datadir}; please run "install_desimodel_data" from the command line or "desimodel.install.main()" from a python prompt; see https://github.com/desihub/desimodel for details.')
+        return False
+    else:
+        return True
 
 _check_datadir()


### PR DESCRIPTION
This PR implements #196 to log a warning message if the desimodel data directory isn't installed.

I found that I needed to do this within desimodel/io.py instead of desimodel/__init__.py since the top level module is imported at pip installation time, and importing things like `desimodel.io.datadir` led to knock-on effects like needing to import `yaml` which doesn't work unless running with `pip install --no-build-isolation ...`.  As a result, the warning message will get printed if `desimodel.io` is imported (the part that needs the data directory) but will not be printed from a bare `import desimodel`. I think that's a feature not a bug.

@weaverba137 please check if this matches what you were suggesting.

Example from a fresh environment without desimodel installed yet:
```
# confirm that desimodel isn't installed
(desitest) [check_datadir*] desimodel $ python -c "import desimodel"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import desimodel
ModuleNotFoundError: No module named 'desimodel'

# install desimodel
(desitest) [check_datadir*] desimodel $ pip install .
Processing /Users/sbailey/desi/git/desimodel
...
Successfully installed desimodel-0.19.3.dev830

# importing bare desimodel should be ok
(desitest) [check_datadir*] desimodel $ python -c "import desimodel"

# but importing desimodel.io should print a warning
(desitest) [check_datadir*] desimodel $ python -c "import desimodel.io"
WARNING:io.py:787:_check_datadir: Missing /Users/sbailey/miniforge3/envs/desitest/lib/python3.13/site-packages/desimodel/data; please run "install_desimodel_data" from the commandline or "desimodel.install.main()" from a python prompt

# installing desimodel data makes the warning message go away
(desitest) [check_datadir*] desimodel $ install_desimodel_data
Installing desimodel data trunk to /Users/sbailey/miniforge3/envs/desitest/lib/python3.13/site-packages/desimodel
(desitest) [check_datadir*] desimodel $ python -c "import desimodel.io"

[no warning message printed]
```